### PR TITLE
Client-Server Ping Assignment

### DIFF
--- a/citadel_sdk/examples/client_ping.rs
+++ b/citadel_sdk/examples/client_ping.rs
@@ -1,0 +1,63 @@
+use citadel_proto::prelude::{
+    EncryptionAlgorithm, KemAlgorithm, SecrecyMode, SecureProtocolPacket,
+    SessionSecuritySettingsBuilder, UdpMode,
+};
+use citadel_sdk::prefabs::client::single_connection::SingleClientServerConnectionKernel;
+use citadel_sdk::prelude::NodeBuilder;
+use futures::StreamExt;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() {
+    std::println!(" Client is now attempting to connect to server... \n");
+
+    let uuid = Uuid::new_v4();
+
+    let session_security = SessionSecuritySettingsBuilder::default()
+        .with_secrecy_mode(SecrecyMode::BestEffort)
+        .with_crypto_params(KemAlgorithm::Kyber + EncryptionAlgorithm::AES_GCM_256)
+        .build()
+        .unwrap();
+
+    let client_kernel = SingleClientServerConnectionKernel::new_passwordless(
+        uuid,
+        SocketAddr::from_str("127.0.0.1:25021").unwrap(),
+        UdpMode::Enabled,
+        session_security,
+        move |connect_success, remote| async move {
+
+            std::println!(" Client has successfully connected..! \n");
+
+            let (sink, mut stream) = connect_success.channel.split();
+
+            let ping = SecureProtocolPacket::from(b"ping" as &[u8]);
+            sink.send_message(ping).await.unwrap();
+
+            std::println!(" Ping message sent... waiting... \n");
+
+            let response = stream.next().await;
+            match response.unwrap().as_ref() {
+                b"pong" => std::println!(" PONG RECEIVED... \n"),
+                _ => std::println!(" PONG NOT RECEIVED... \n"),
+            }
+
+            std::println!(" Client can now close connection... \n");
+
+            remote.shutdown_kernel().await?;
+
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    let client = NodeBuilder::default().with_insecure_skip_cert_verification().build(client_kernel).unwrap();
+
+    let _result = match client.await {
+        Ok(_result) => _result,
+        Err(error) => panic!("Problem connecting to server: {:?}", error),
+    };
+
+    std::println!(" Client now closing... \n");
+}

--- a/citadel_sdk/examples/server_ping.rs
+++ b/citadel_sdk/examples/server_ping.rs
@@ -1,0 +1,44 @@
+use citadel_proto::prelude::NodeType;
+use citadel_sdk::prefabs::server::client_connect_listener::ClientConnectListenerKernel;
+use citadel_sdk::prelude::*;
+use futures::StreamExt;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+#[tokio::main]
+async fn main() {
+    std::println!(" Server is now listening..! \n");
+
+    let server = NodeBuilder::default()
+        .with_insecure_skip_cert_verification()
+        .with_node_type(NodeType::server(SocketAddr::from_str("127.0.0.1:25021").unwrap()).unwrap())
+        .build(ClientConnectListenerKernel::new(
+            move |connect_success, _remote| async move {
+
+                std::println!(" Client has successfully connected..! \n");
+
+                let (sink, mut stream) = connect_success.channel.split();
+
+                let response = stream.next().await;
+                match response.unwrap().as_ref() {
+                    b"ping" => std::println!(" PING RECEIVED... \n"),
+                    _ => std::println!(" PING NOT RECEIVED... \n"),
+                }
+
+                let ping = SecureProtocolPacket::from(b"pong" as &[u8]);
+                sink.send_message(ping).await.unwrap();
+
+                std::println!(" Connection closing... \n");
+
+                Ok(())
+            },
+        ))
+        .unwrap();
+
+        let _result = match server.await {
+            Ok(_result) => _result,
+            Err(error) => panic!("Problem waiting for client connection: {:?}", error),
+        };
+
+    std::println!(" Server is now shutting down... \n");
+}


### PR DESCRIPTION
Client and Server Ping example using the Citadel SDK. Once server is run, it can be "pinged" by client program repeatedly. Client "pings" the server and closes after receiving a "pong" response.