### PR TITLE
Draft: Post-Quantum Decentralized Group Chat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,4 @@ once_cell = { default-features = false, version = "1.17.0" }
 webrtc-util = { version = "0.8.0" }
 embed-doc-image = { version = "0.1.4" }
 hyper = { version = "0.14.25" }
+md5 = { version = "0.7.0" }

--- a/citadel_pqcrypto/Cargo.toml
+++ b/citadel_pqcrypto/Cargo.toml
@@ -49,6 +49,7 @@ serde-big-array = { workspace = true }
 ascon-aead = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive", "alloc", "serde"] }
 citadel_types = { workspace = true }
+md5 = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 oqs = { workspace = true, features = ["serde", "falcon", "ntruprime"] }

--- a/citadel_pqcrypto/src/group/group_pq_impls.rs
+++ b/citadel_pqcrypto/src/group/group_pq_impls.rs
@@ -1,0 +1,102 @@
+use crate::group::PostQuantumKexGroup;
+use aes_gcm::aead::Aead;
+use aes_gcm::KeyInit;
+use citadel_types::prelude::{SecBuffer, AES_GCM_NONCE_LENGTH_BYTES};
+
+pub struct Kyber1024WithAes256Gcm {
+    public_key: SecBuffer,
+    private_key: SecBuffer,
+}
+
+impl Kyber1024WithAes256Gcm {
+    pub fn new(public_key: SecBuffer, private_key: SecBuffer) -> Self {
+        Self {
+            public_key,
+            private_key,
+        }
+    }
+}
+
+impl PostQuantumKexGroup for Kyber1024WithAes256Gcm {
+    fn symmetric_encrypt(&self, symmetric_key: &[u8], plaintext: &[u8], nonce: &[u8]) -> SecBuffer {
+        let aes =
+            aes_gcm::Aes256Gcm::new_from_slice(symmetric_key).expect("Should be correct size");
+        let nonce = aes_gcm::Nonce::from_slice(&nonce[..AES_GCM_NONCE_LENGTH_BYTES]);
+        aes.encrypt(nonce, plaintext)
+            .expect("Should be correct size")
+            .into()
+    }
+
+    fn symmetric_decrypt(
+        &self,
+        symmetric_key: &[u8],
+        ciphertext: &[u8],
+        nonce: &[u8],
+    ) -> Option<SecBuffer> {
+        let aes =
+            aes_gcm::Aes256Gcm::new_from_slice(symmetric_key).expect("Should be correct size");
+        let nonce = aes_gcm::Nonce::from_slice(&nonce[..AES_GCM_NONCE_LENGTH_BYTES]);
+        aes.decrypt(nonce, ciphertext).ok().map(|x| x.into())
+    }
+
+    fn asymmetric_encrypt(&self, public_key: &[u8], plaintext: &[u8], nonce: &[u8]) -> SecBuffer {
+        kyber_pke::encrypt(public_key, plaintext, nonce)
+            .expect("Should encrypt")
+            .into()
+    }
+
+    fn asymmetric_decrypt(&self, ciphertext: &[u8], _nonce: &[u8]) -> Option<SecBuffer> {
+        kyber_pke::decrypt(&self.private_key, ciphertext)
+            .ok()
+            .map(|x| x.into())
+    }
+
+    fn public_key(&self) -> &SecBuffer {
+        &self.public_key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::PostQuantumKexGroup;
+    use rand::RngCore;
+
+    #[test]
+    fn test_kyber1024_with_aes256_gcm() {
+        let mut rng = rand::thread_rng();
+        let mut symmetric_key = [0u8; 32];
+        rng.fill_bytes(&mut symmetric_key);
+        let mut plaintext = [0u8; 32];
+        rng.fill_bytes(&mut plaintext);
+        let mut nonce = [0u8; 12];
+        rng.fill_bytes(&mut nonce);
+
+        let (pk, sk) = kyber_pke::pke_keypair().unwrap();
+        let group = Kyber1024WithAes256Gcm::new(pk.to_vec().into(), sk.to_vec().into());
+
+        let ciphertext = group.symmetric_encrypt(&symmetric_key, &plaintext, &nonce);
+        let decrypted = group
+            .symmetric_decrypt(&symmetric_key, ciphertext.as_ref(), &nonce)
+            .unwrap();
+        assert_eq!(plaintext, decrypted.as_ref());
+    }
+
+    #[test]
+    fn test_kyber1024_asymmetric() {
+        let mut rng = rand::thread_rng();
+        let mut plaintext = [0u8; 32];
+        rng.fill_bytes(&mut plaintext);
+        let mut nonce = [0u8; 32];
+        rng.fill_bytes(&mut nonce);
+
+        let (pk, sk) = kyber_pke::pke_keypair().unwrap();
+        let group = Kyber1024WithAes256Gcm::new(pk.to_vec().into(), sk.to_vec().into());
+
+        let ciphertext = group.asymmetric_encrypt(group.public_key().as_ref(), &plaintext, &nonce);
+        let decrypted = group
+            .asymmetric_decrypt(ciphertext.as_ref(), &nonce)
+            .unwrap();
+        assert_eq!(plaintext, decrypted.as_ref());
+    }
+}

--- a/citadel_pqcrypto/src/group/mod.rs
+++ b/citadel_pqcrypto/src/group/mod.rs
@@ -1,0 +1,179 @@
+use citadel_types::prelude::SecBuffer;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub mod group_pq_impls;
+
+pub type IdentityHash = [u8; 16];
+
+pub struct PostQuantumGroup {
+    // The hash of our public key
+    my_id_hash: Arc<IdentityHash>,
+    method: Arc<dyn PostQuantumKexGroup>,
+    // A mapping of peer ids to their public keys
+    peer_ids: Arc<parking_lot::RwLock<HashMap<IdentityHash, SecBuffer>>>,
+}
+
+pub trait PostQuantumKexGroup: 'static {
+    // The symmetric key is always randomly generated
+    fn symmetric_encrypt(&self, symmetric_key: &[u8], plaintext: &[u8], nonce: &[u8]) -> SecBuffer;
+    fn symmetric_decrypt(
+        &self,
+        symmetric_key: &[u8],
+        ciphertext: &[u8],
+        nonce: &[u8],
+    ) -> Option<SecBuffer>;
+    fn asymmetric_encrypt(&self, public_key: &[u8], plaintext: &[u8], nonce: &[u8]) -> SecBuffer;
+    fn asymmetric_decrypt(&self, ciphertext: &[u8], nonce: &[u8]) -> Option<SecBuffer>;
+    fn public_key(&self) -> &SecBuffer;
+}
+
+/// We don't need cryptographic security here, just a hash function that is fast and has a low collision rate
+/// The inputs should be public inputs
+fn hash_function<T: AsRef<[u8]>>(input: T) -> IdentityHash {
+    md5::compute(input).0
+}
+
+impl PostQuantumGroup {
+    pub fn new<T: PostQuantumKexGroup>(method: T) -> Self {
+        let my_id_hash = hash_function(method.public_key());
+
+        Self {
+            my_id_hash: Arc::new(my_id_hash),
+            method: Arc::new(method),
+            peer_ids: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn add_peer(&self, peer_public_key: SecBuffer) {
+        let peer_id = hash_function(&peer_public_key);
+        self.peer_ids.write().insert(peer_id, peer_public_key);
+    }
+
+    pub fn remove_peer(&self, peer_public_key: SecBuffer) {
+        let peer_id = hash_function(&peer_public_key);
+        self.peer_ids.write().remove(&peer_id);
+    }
+
+    /// The function will first generate a random symmetric key of 32 bytes in length
+    /// Then, it will symmetrically encrypt it into a ciphertext using this random symmetric key and the plaintext/nonce.
+    /// Then, it will asymmetrically encrypt the random symmetric key using the public key of each recipient.
+    /// Finally, it will return a GroupMessage containing the ciphertext, the encrypted symmetric keys, and the nonce.
+    pub fn encrypt(&self, plaintext: &[u8]) -> Transmission {
+        let symmetric_key = rand::random::<[u8; 32]>();
+        let nonce = rand::random::<[u8; 32]>();
+        let ciphertext = self
+            .method
+            .symmetric_encrypt(&symmetric_key, plaintext, &nonce);
+
+        let mut encrypted_keys = HashMap::new();
+        for (peer_id, peer_public_key) in self.peer_ids.read().iter() {
+            let asymmetric_nonce = rand::random::<[u8; 32]>();
+            encrypted_keys.insert(
+                *peer_id,
+                GroupMessageTarget {
+                    ciphertext: self.method.asymmetric_encrypt(
+                        peer_public_key.as_ref(),
+                        &symmetric_key,
+                        &asymmetric_nonce,
+                    ),
+                    asymmetric_nonce: asymmetric_nonce.into(),
+                },
+            );
+        }
+
+        Transmission::Broadcast(GroupMessage {
+            ciphertext,
+            encrypted_keys,
+            nonce: nonce.into(),
+        })
+    }
+
+    pub fn decrypt(&self, mut message: GroupMessage) -> Option<SecBuffer> {
+        let my_payload = message.encrypted_keys.remove(&*self.my_id_hash)?;
+
+        let encrypted_symmetric_key = my_payload.ciphertext;
+        let asymmetric_nonce = my_payload.asymmetric_nonce;
+        let symmetric_key = self
+            .method
+            .asymmetric_decrypt(encrypted_symmetric_key.as_ref(), asymmetric_nonce.as_ref())?;
+        self.method.symmetric_decrypt(
+            symmetric_key.as_ref(),
+            message.ciphertext.as_ref(),
+            message.nonce.as_ref(),
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum Transmission {
+    Broadcast(GroupMessage),
+    AddPeer(AddPeer),
+    RemovePeer(RemovePeer),
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct GroupMessage {
+    ciphertext: SecBuffer,
+    // A map from the hash of the public keys of the recipients to the encrypted symmetric key used to encrypt the message
+    // Note: the symmetric key is always randomly generated
+    encrypted_keys: HashMap<IdentityHash, GroupMessageTarget>,
+    nonce: SecBuffer,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct GroupMessageTarget {
+    pub ciphertext: SecBuffer,
+    pub asymmetric_nonce: SecBuffer,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct AddPeer {
+    pub peer_public_key: SecBuffer,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RemovePeer {
+    pub peer_public_key: SecBuffer,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::group::group_pq_impls::Kyber1024WithAes256Gcm;
+
+    #[test]
+    fn test_group() {
+        let plaintext = b"Hello, world!" as &[u8];
+
+        let (pk, sk) = kyber_pke::pke_keypair().unwrap();
+        let (pk2, sk2) = kyber_pke::pke_keypair().unwrap();
+        let group = PostQuantumGroup::new(Kyber1024WithAes256Gcm::new(
+            pk.to_vec().into(),
+            sk.to_vec().into(),
+        ));
+        let group_member2 = PostQuantumGroup::new(Kyber1024WithAes256Gcm::new(
+            pk2.to_vec().into(),
+            sk2.to_vec().into(),
+        ));
+
+        group.add_peer(pk2.to_vec().into());
+        group_member2.add_peer(pk.to_vec().into());
+
+        let ciphertext = group.encrypt(&plaintext);
+        let Transmission::Broadcast(message) = ciphertext else {
+            panic!("Should be correct type")
+        };
+        let decrypted = group_member2.decrypt(message).unwrap();
+        assert_eq!(plaintext, decrypted.as_ref());
+
+        // Now, try sending a message from group member2 to group member1
+        let ciphertext = group_member2.encrypt(&plaintext);
+        let Transmission::Broadcast(message) = ciphertext else {
+            panic!("Should be correct type")
+        };
+        let decrypted = group.decrypt(message).unwrap();
+        assert_eq!(plaintext, decrypted.as_ref());
+    }
+}

--- a/citadel_pqcrypto/src/lib.rs
+++ b/citadel_pqcrypto/src/lib.rs
@@ -31,6 +31,7 @@ pub mod prelude {
 }
 
 pub mod bytes_in_place;
+pub mod group;
 
 /// For handling serialization/deserialization
 pub mod export;


### PR DESCRIPTION
Post-Quantum Decentralized Group Chat (PQGC)

* PQGC will first generate a cryptographically-secure random symmetric key of 32 bytes in length (as well as a nonce)
* PQGC will then use a symmetric block cipher to encrypt the input plaintext using this random symmetric key and random nonce
* PQGC will then asymmetrically encrypt the random symmetric key using the public key of each group member to generate `n` encrypted symmetric keys
* Finally, PQGC will return a GroupMessage containing the ciphertext, `n` encrypted symmetric keys, and the relevant nonces.

The message size in bytes is `32n + ciphertext_len(message)`. The 32n part is figured because there will be `n` 32-byte kyber ciphertexts for the encrypted symmetric key, and `ciphertext_len(message)` is the output length of the symmetric block cipher against the input message. The message size is kept relatively small, and even with 1000 participants, the message is ~32KB which is highly acceptable for modern networks.

TODO:

* Authenticity via signing
* Ratcheting and forward secrecy
* Move from options to errors
* Fix invalid nonce sized inputs into kyber-pke (causes panics)