### PR TITLE
Refactor: Use spawn_blocking to prevent blocking in async contexts

### DIFF
--- a/citadel_proto/src/proto/packet_processor/connect_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/connect_packet.rs
@@ -57,65 +57,82 @@ pub async fn process_connect<R: Ratchet>(
     packet: HdpPacket,
     header_entropy_bank_vers: u32,
 ) -> Result<PrimaryProcessorResult, NetworkError> {
-    let session = sess_ref.clone();
+    let session_initial_clone = sess_ref.clone(); // Clone for initial sync prefix
 
-    let (hr, cnac) = {
-        let state_container = inner_state!(session.state_container);
-        if !session.is_provisional()
-            && state_container.connect_state.last_stage
-                != packet_flags::cmd::aux::do_connect::SUCCESS
-        {
-            log::error!(target: "citadel", "Connect packet received, but the system is not in a provisional state. Dropping");
-            return Ok(PrimaryProcessorResult::Void);
-        }
+    // Synchronous prefix to be run in spawn_blocking
+    let initial_sync_data = tokio::task::spawn_blocking(move || {
+        let session = session_initial_clone; // Use cloned session
+        let (hr, cnac, initial_header_bytes, initial_payload_bytes) = {
+            let state_container = inner_state!(session.state_container);
+            if !session.is_provisional()
+                && state_container.connect_state.last_stage
+                    != packet_flags::cmd::aux::do_connect::SUCCESS
+            {
+                log::error!(target: "citadel", "Connect packet received, but the system is not in a provisional state. Dropping");
+                // Return a specific error or indicator that can be handled after await
+                return Err(NetworkError::InvalidState("Not in provisional state for connect"));
+            }
 
-        if !state_container.pre_connect_state.success {
-            log::error!(target: "citadel", "Connect packet received, but the system has not yet completed the pre-connect stage. Dropping");
-            return Ok(PrimaryProcessorResult::Void);
-        }
+            if !state_container.pre_connect_state.success {
+                log::error!(target: "citadel", "Connect packet received, but the system has not yet completed the pre-connect stage. Dropping");
+                return Err(NetworkError::InvalidState("Pre-connect not complete"));
+            }
 
-        let hr = return_if_none!(
-            get_orientation_safe_ratchet(header_entropy_bank_vers, &state_container, None),
-            "Could not get proper HR [connect]"
-        );
-        let cnac = return_if_none!(state_container.cnac.clone(), "CNAC missing");
-        (hr, cnac)
-    };
+            let hr = get_orientation_safe_ratchet(header_entropy_bank_vers, &state_container, None)
+                .ok_or(NetworkError::InternalError("Could not get proper HR [connect]"))?;
+            let cnac = state_container.cnac.clone()
+                .ok_or(NetworkError::InternalError("CNAC missing"))?;
+            
+            let (header_bytes, payload_bytes, _, _) = packet.decompose_arc(); // Assuming decompose_arc or similar for owned parts
+            (hr, cnac, header_bytes, payload_bytes)
+        };
 
-    let (header, payload, _, _) = packet.decompose();
+        // AEAD validation
+        let (validated_header_ref, validated_payload, validated_ratchet) = 
+            validation::aead::validate(hr, &initial_header_bytes, BytesMut::from(&initial_payload_bytes[..]))
+            .ok_or(NetworkError::InternalError("Unable to validate connect packet (AEAD)"))?;
+        
+        // We need to return owned data from the blocking task
+        let owned_header = parsed_header_from_ref(&validated_header_ref); // Helper needed
 
-    let (header, payload, ratchet) = return_if_none!(
-        validation::aead::validate(hr, &header, payload),
-        "Unable to validate connect packet"
-    );
-    let header = header.clone();
+        Ok((owned_header, validated_payload, validated_ratchet, cnac))
+    }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for initial connect processing failed: {}", e)))??;
+
+    let (header, payload, ratchet, cnac) = initial_sync_data; // Destructure owned data
     let security_level = header.security_level.into();
-
-    let time_tracker = session.time_tracker;
+    let time_tracker = sess_ref.time_tracker; // Can access non-locked parts of original sess_ref if needed, or pass from above
+    let session = sess_ref.clone(); // Re-clone for the async task below if original sess_ref is not 'static
 
     let task = async move {
-        let session = &session;
+        let session = &session; // Use the new clone of session
         match header.cmd_aux {
             // Node is Bob. Bob gets the encrypted username and password (separately encrypted)
             packet_flags::cmd::aux::do_connect::STAGE0 => {
                 log::trace!(target: "citadel", "STAGE 0 CONNECT PACKET");
-                let task = {
-                    match validation::do_connect::validate_stage0_packet(&cnac, &payload).await {
-                        Ok(stage0_packet) => {
-                            let mut state_container = inner_mut_state!(session.state_container);
+                
+                // validate_stage0_packet is async, so it's called outside spawn_blocking here
+                // but it needs to handle its own internal blocking calls if any
+                match validation::do_connect::validate_stage0_packet(&cnac, &payload).await {
+                    Ok(stage0_packet) => {
+                        // Operations after validate_stage0_packet that need blocking lock
+                        let session_clone_for_blocking = session.clone();
+                        let ratchet_clone_for_blocking = ratchet.clone();
+                        let cnac_clone_for_blocking = cnac.clone();
+                        let kernel_ticket_val = session.kernel_ticket.get(); // Atomic
+                        let remote_peer_addr = session.remote_peer; // Copy
+                        let is_server_val = session.is_server; // Copy
+
+                        tokio::task::spawn_blocking(move || {
+                            let mut state_container = inner_mut_state!(session_clone_for_blocking.state_container);
                             let local_uses_file_system = matches!(
-                                session.account_manager.get_backend_type(),
+                                session_clone_for_blocking.account_manager.get_backend_type(),
                                 BackendType::Filesystem(..)
                             );
-                            session
+                            session_clone_for_blocking
                                 .file_transfer_compatible
                                 .set_once(local_uses_file_system && stage0_packet.uses_filesystem);
-                            let cid = ratchet.get_cid();
-                            let success_time = session.time_tracker.get_global_time_ns();
-                            let addr = session.remote_peer;
-                            let is_personal = !session.is_server;
-                            let kernel_ticket = session.kernel_ticket.get();
-
+                            let cid = ratchet_clone_for_blocking.get_cid();
+                            
                             state_container.connect_state.last_stage =
                                 packet_flags::cmd::aux::do_connect::SUCCESS;
                             state_container.connect_state.fail_time = None;
@@ -126,334 +143,335 @@ pub async fn process_connect<R: Ratchet>(
                                 .rx
                                 .take();
                             let channel = state_container.init_new_c2s_virtual_connection(
-                                &cnac,
-                                kernel_ticket,
-                                header.session_cid.get(),
-                                session,
+                                &cnac_clone_for_blocking, // Use cloned cnac
+                                kernel_ticket_val,
+                                header.session_cid.get(), // header is owned from initial spawn_blocking
+                                &session_clone_for_blocking,
                             );
 
                             let session_security_settings = state_container
                                 .session_security_settings
                                 .expect("Should be set");
-
-                            drop(state_container);
-
-                            // Upgrade the connect BEFORE updating the CNAC
-                            if !session.session_manager.upgrade_connection(addr, cid) {
-                                return Ok(PrimaryProcessorResult::EndSession("Unable to upgrade from a provisional to a protected connection (Server)"));
+                            
+                            // Upgrade connection (synchronous, uses lock on session_manager)
+                            if !session_clone_for_blocking.session_manager.upgrade_connection(remote_peer_addr, cid) {
+                                // Cannot directly return Ok(PrimaryProcessorResult...) from spawn_blocking if it needs to be async reply
+                                // This part needs careful refactoring. For now, returning error to be handled by outer async.
+                                return Err(NetworkError::InternalError("Unable to upgrade from a provisional to a protected connection (Server)"));
                             }
 
-                            // register w/ peer layer, get mail in the process
-                            let account_manager = session.account_manager.clone();
+                            Ok((cid, udp_channel_rx, channel, session_security_settings, ratchet_clone_for_blocking, is_server_val, kernel_ticket_val, remote_peer_addr ))
+                        }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for STAGE0 post-validation failed: {}", e)))??
+                        .then(|(cid, udp_channel_rx, channel, session_security_settings, ratchet_for_reply, is_server_val, kernel_ticket_val, remote_peer_addr)| async move { // Use .then to chain async work
+                            let mailbox_items = session // Use original session Arc here or pass clones appropriately
+                                .session_manager
+                                .register_session_with_peer_layer(cid)
+                                .await?;
+                            let peers = session.account_manager
+                                .get_persistence_handler()
+                                .get_hyperlan_peer_list_as_server(cid)
+                                .await?
+                                .unwrap_or_default();
 
-                            async move {
-                                let mailbox_items = session
-                                    .session_manager
-                                    .register_session_with_peer_layer(cid)
-                                    .await?;
-                                let peers = account_manager
-                                    .get_persistence_handler()
-                                    .get_hyperlan_peer_list_as_server(cid)
-                                    .await?
-                                    .unwrap_or_default();
+                            #[cfg(feature = "google-services")]
+                            let post_login_object = session.account_manager
+                                .services_handler()
+                                .on_post_login_serverside(cid)
+                                .await?;
+                            #[cfg(not(feature = "google-services"))]
+                            let post_login_object =
+                                citadel_user::external_services::ServicesObject::default();
+                            
+                            let success_time = session.time_tracker.get_global_time_ns(); // Access non-locking field or pass from sync block
 
-                                #[cfg(feature = "google-services")]
-                                let post_login_object = account_manager
-                                    .services_handler()
-                                    .on_post_login_serverside(cid)
-                                    .await?;
-                                #[cfg(not(feature = "google-services"))]
-                                let post_login_object =
-                                    citadel_user::external_services::ServicesObject::default();
+                            let success_packet =
+                                packet_crafter::do_connect::craft_final_status_packet(
+                                    &ratchet_for_reply, // Use ratchet from blocking task's result
+                                    true,
+                                    mailbox_items,
+                                    post_login_object.clone(),
+                                    session.create_welcome_message(cid),
+                                    peers,
+                                    success_time,
+                                    security_level, // Original security_level
+                                    session.account_manager.get_backend_type(),
+                                );
+                            
+                            // These are now safe as they are on the original session Arc after await
+                            session.session_cid.set(Some(cid)); 
+                            session.state.set(SessionState::Connected);
 
-                                let success_packet =
-                                    packet_crafter::do_connect::craft_final_status_packet(
-                                        &ratchet,
-                                        true,
-                                        mailbox_items,
-                                        post_login_object.clone(),
-                                        session.create_welcome_message(cid),
-                                        peers,
-                                        success_time,
-                                        security_level,
-                                        session.account_manager.get_backend_type(),
-                                    );
-
-                                session.session_cid.set(Some(cid));
-                                session.state.set(SessionState::Connected);
-
-                                let cxn_type =
-                                    VirtualConnectionType::LocalGroupServer { session_cid: cid };
-                                let channel_signal = NodeResult::ConnectSuccess(ConnectSuccess {
-                                    ticket: kernel_ticket,
-                                    session_cid: cid,
-                                    remote_addr: addr,
-                                    is_personal,
-                                    v_conn_type: cxn_type,
-                                    services: post_login_object,
-                                    welcome_message: format!("Client {cid} successfully established a connection to the local HyperNode"),
-                                    channel,
-                                    udp_rx_opt: udp_channel_rx,
-                                    session_security_settings,
-                                });
-                                // safe unwrap. Store the signal
-                                inner_mut_state!(session.state_container)
+                            let cxn_type =
+                                VirtualConnectionType::LocalGroupServer { session_cid: cid };
+                            let channel_signal = NodeResult::ConnectSuccess(ConnectSuccess {
+                                ticket: kernel_ticket_val,
+                                session_cid: cid,
+                                remote_addr: remote_peer_addr,
+                                is_personal: !is_server_val,
+                                v_conn_type: cxn_type,
+                                services: post_login_object,
+                                welcome_message: format!("Client {cid} successfully established a connection to the local HyperNode"),
+                                channel,
+                                udp_rx_opt: udp_channel_rx,
+                                session_security_settings,
+                            });
+                            
+                            // This lock needs to be async or also in spawn_blocking if it's blocking
+                            let session_clone_for_signal = session.clone();
+                            tokio::task::spawn_blocking(move || {
+                                inner_mut_state!(session_clone_for_signal.state_container)
                                     .get_endpoint_container_mut(C2S_IDENTITY_CID)
                                     .as_mut()
                                     .unwrap()
                                     .channel_signal = Some(channel_signal);
-                                Ok(PrimaryProcessorResult::ReplyToSender(success_packet))
-                            }
-                        }
-
-                        Err(err) => {
-                            log::error!(target: "citadel", "Error validating stage2 packet. Reason: {err}");
-                            let fail_time = time_tracker.get_global_time_ns();
-
-                            //session.state = SessionState::NeedsConnect;
-                            let packet = packet_crafter::do_connect::craft_final_status_packet(
-                                &ratchet,
-                                false,
-                                None,
-                                ServicesObject::default(),
-                                err.to_string(),
-                                Vec::new(),
-                                fail_time,
-                                security_level,
-                                session.account_manager.get_backend_type(),
-                            );
-                            return Ok(PrimaryProcessorResult::ReplyToSender(packet));
-                        }
+                            }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for channel_signal set failed: {}", e)))?;
+                            
+                            Ok(PrimaryProcessorResult::ReplyToSender(success_packet))
+                        }).await
                     }
-                };
 
-                task.await
+                    Err(err) => { // Error from validate_stage0_packet
+                        log::error!(target: "citadel", "Error validating stage0 packet. Reason: {err}");
+                        let fail_time = time_tracker.get_global_time_ns(); // time_tracker is from original scope
+
+                        let packet = packet_crafter::do_connect::craft_final_status_packet(
+                            &ratchet, // ratchet is from initial_sync_data
+                            false,
+                            None,
+                            ServicesObject::default(),
+                            err.to_string(),
+                            Vec::new(),
+                            fail_time,
+                            security_level, // original security_level
+                            session.account_manager.get_backend_type(), // Access non-locking part or pass from sync
+                        );
+                        return Ok(PrimaryProcessorResult::ReplyToSender(packet));
+                    }
+                }
             }
 
             packet_flags::cmd::aux::do_connect::FAILURE => {
                 log::trace!(target: "citadel", "STAGE FAILURE CONNECT PACKET");
-                let kernel_ticket = session.kernel_ticket.get();
+                let session_clone_failure = session.clone();
+                let payload_clone_failure = payload.clone(); // Bytes is cheap to clone
+                let ratchet_clone_failure = ratchet.clone(); // Ratchet must be Clone
+                let header_clone_failure = header.clone(); // Assuming parsed_header_from_ref returns a clonable Header
 
-                let mut state_container = inner_mut_state!(session.state_container);
-                if let Some(payload) =
-                    validation::do_connect::validate_final_status_packet(&payload)
-                {
-                    let message = String::from_utf8(payload.message.to_vec())
-                        .unwrap_or_else(|_| "Invalid UTF-8 message".to_string());
-                    log::error!(target: "citadel", "The server refused to login the user. Reason: {}", &message);
-                    let cid = ratchet.get_cid();
-                    state_container.connect_state.on_fail();
+                tokio::task::spawn_blocking(move || {
+                    let kernel_ticket = session_clone_failure.kernel_ticket.get(); // Atomic
+
+                    let mut state_container = inner_mut_state!(session_clone_failure.state_container);
+                    if let Some(payload_validated) = // payload_clone_failure used here
+                        validation::do_connect::validate_final_status_packet(&payload_clone_failure)
+                    {
+                        let message = String::from_utf8(payload_validated.message.to_vec())
+                            .unwrap_or_else(|_| "Invalid UTF-8 message".to_string());
+                        log::error!(target: "citadel", "The server refused to login the user. Reason: {}", &message);
+                        let cid = ratchet_clone_failure.get_cid(); // Use cloned ratchet
+                        state_container.connect_state.on_fail();
+                        // Dropping state_container guard before other ops on session if they lock too
+                        drop(state_container);
+
+                        session_clone_failure.session_cid.set(None); // DualRwLock, blocking
+                        session_clone_failure.state.set(SessionState::NeedsConnect); // Atomic, fine
+                        session_clone_failure.disable_dc_signal(); // DualRwLock, blocking
+
+                        session_clone_failure.send_to_kernel(NodeResult::ConnectFail(ConnectFail { // UnboundedSender, non-blocking
+                            ticket: kernel_ticket,
+                            cid_opt: Some(cid),
+                            error_message: message,
+                        }))?;
+                        Ok(PrimaryProcessorResult::EndSession(
+                            "Failed connecting. Try again",
+                        ))
+                    } else {
+                        trace!(target: "citadel", "An invalid FAILURE packet was received; dropping due to invalid signature");
+                        Ok(PrimaryProcessorResult::Void)
+                    }
+                }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for FAILURE branch failed: {}", e)))?
+            }
+
+            packet_flags::cmd::aux::do_connect::SUCCESS => {
+                log::trace!(target: "citadel", "STAGE SUCCESS CONNECT PACKET");
+                // This whole block is complex, involving async calls and sync lock access.
+                // It needs careful sequential application of spawn_blocking for its synchronous parts.
+                // The original structure was: read state -> validate (sync, CPU) -> update state (sync) -> IO (async) -> update state (sync)
+                
+                let session_clone_success_outer = session.clone();
+                let cnac_clone_outer = cnac.clone();
+                let ratchet_clone_outer = ratchet.clone();
+                let header_clone_outer = header.clone();
+                let payload_clone_outer = payload.clone();
+
+                // Task for validation and initial state updates (synchronous part)
+                let (
+                    message, kernel_ticket_val, cid, use_ka, connect_mode_val, 
+                    udp_channel_rx, channel, session_security_settings_val,
+                    addr_val, is_personal_val, mailbox_delivery_val, peers_val,
+                    backend_type_val, success_time_val
+                ) = tokio::task::spawn_blocking(move || {
+                    let mut state_container = inner_mut_state!(session_clone_success_outer.state_container);
+                    let last_stage = state_container.connect_state.last_stage;
+                    let remote_uses_filesystem = header_clone_outer.group.get() != 0;
+                    let local_uses_file_system = matches!(
+                        session_clone_success_outer.account_manager.get_backend_type(),
+                        BackendType::Filesystem(..)
+                    );
+                    session_clone_success_outer
+                        .file_transfer_compatible
+                        .set_once(local_uses_file_system && remote_uses_filesystem);
+
+                    if last_stage != packet_flags::cmd::aux::do_connect::STAGE1 {
+                        log::error!(target: "citadel", "An invalid SUCCESS packet was received; dropping since the last local stage was not stage 1");
+                        return Err(NetworkError::InvalidState("Last stage was not STAGE1 for SUCCESS packet"));
+                    }
+
+                    let validated_payload = validation::do_connect::validate_final_status_packet(&payload_clone_outer)
+                        .ok_or(NetworkError::InvalidPacket("Invalid SUCCESS packet; deserialization/validation failed"))?;
+                    
+                    let msg = String::from_utf8(validated_payload.message.to_vec())
+                        .unwrap_or_else(|_| String::from("Invalid message"));
+                    let kt = session_clone_success_outer.kernel_ticket.get();
+                    let r_cid = ratchet_clone_outer.get_cid();
+
+                    state_container.connect_state.on_success();
+                    state_container.connect_state.on_connect_packet_received();
+
+                    let ka = state_container.keep_alive_timeout_ns != 0;
+                    let cm = state_container.connect_state.connect_mode.ok_or(NetworkError::InternalError("Unable to load connect mode"))?;
+                    let udp_rx = state_container.pre_connect_state.udp_channel_oneshot_tx.rx.take();
+                    let ch = state_container.init_new_c2s_virtual_connection(
+                        &cnac_clone_outer, kt, header_clone_outer.session_cid.get(), &session_clone_success_outer
+                    );
+                    let sss = state_container.session_security_settings.expect("Should be set");
+                    
+                    // Release state_container lock before other potentially locking session operations
                     drop(state_container);
 
-                    session.session_cid.set(None);
-                    session.state.set(SessionState::NeedsConnect);
-                    session.disable_dc_signal();
+                    session_clone_success_outer.session_cid.set(Some(r_cid));
+                    if !session_clone_success_outer.session_manager.upgrade_connection(session_clone_success_outer.remote_peer, r_cid) {
+                        return Err(NetworkError::InternalError("Unable to upgrade from a provisional to a protected connection (Client)"));
+                    }
+                    session_clone_success_outer.state.set(SessionState::Connected);
+                    
+                    let s_addr = session_clone_success_outer.remote_peer;
+                    let s_is_personal = !session_clone_success_outer.is_server;
+                    let s_backend_type = session_clone_success_outer.account_manager.get_backend_type();
+                    let s_success_time = session_clone_success_outer.time_tracker.get_global_time_ns();
 
-                    session.send_to_kernel(NodeResult::ConnectFail(ConnectFail {
-                        ticket: kernel_ticket,
-                        cid_opt: Some(cid),
-                        error_message: message,
-                    }))?;
-                    Ok(PrimaryProcessorResult::EndSession(
-                        "Failed connecting. Try again",
-                    ))
+                    Ok((msg, kt, r_cid, ka, cm, udp_rx, ch, sss, s_addr, s_is_personal, validated_payload.mailbox, validated_payload.peers, s_backend_type, s_success_time, validated_payload.post_login_object))
+                }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for SUCCESS validation/state update failed: {}", e)))??;
+                
+                log::trace!(target: "citadel", "The login to the server was a success. Welcome Message: {}", &message);
+
+                let success_ack = packet_crafter::do_connect::craft_success_ack(
+                    &ratchet, // Use original ratchet from initial_sync_data
+                    success_time_val,
+                    security_level, // Original security_level
+                );
+                session.send_to_primary_stream(None, success_ack)?; // session is original Arc
+
+                session.send_to_kernel(NodeResult::ConnectSuccess(ConnectSuccess {
+                    ticket: kernel_ticket_val,
+                    session_cid: cid,
+                    remote_addr: addr_val,
+                    is_personal: is_personal_val,
+                    v_conn_type: VirtualConnectionType::LocalGroupServer { session_cid: cid },
+                    services: initial_sync_data.3, // Assuming post_login_object was part of initial_sync_data tuple's 4th element or passed correctly
+                    welcome_message: message,
+                    channel,
+                    udp_rx_opt: udp_channel_rx,
+                    session_security_settings: session_security_settings_val,
+                }))?;
+
+                if let Some(mailbox_delivery) = mailbox_delivery_val {
+                    session.send_to_kernel(NodeResult::MailboxDelivery(
+                        MailboxDelivery {
+                            session_cid: cid,
+                            ticket_opt: None,
+                            items: mailbox_delivery,
+                        },
+                    ))?;
+                }
+                
+                let persistence_handler = session.account_manager.get_persistence_handler().clone();
+                let cnac_for_sync = cnac.clone(); // cnac from initial_sync_data
+                let post_login_object_for_sync = initial_sync_data.3; // Assuming it's the 4th element
+
+                // Async post-processing
+                persistence_handler
+                    .synchronize_hyperlan_peer_list_as_client(&cnac_for_sync, peers_val)
+                    .await?;
+                
+                #[cfg(feature = "google-services")]
+                if let (Some(rtdb_cfg), Some(jwt)) =
+                    (post_login_object_for_sync.rtdb, post_login_object_for_sync.google_auth_jwt)
+                {
+                    log::trace!(target: "citadel", "Client detected RTDB config + Google Auth web token. Will login + store config to CNAC ...");
+                    let rtdb =
+                        citadel_user::re_exports::FirebaseRTDB::new_from_jwt(
+                            &rtdb_cfg.url,
+                            jwt.clone(),
+                            rtdb_cfg.api_key.clone(),
+                        )
+                        .await
+                        .map_err(|err| NetworkError::Generic(err.inner))?; // login
+
+                    let citadel_user::re_exports::FirebaseRTDB {
+                        base_url,
+                        auth,
+                        expire_time,
+                        api_key,
+                        jwt,
+                        ..
+                    } = rtdb;
+
+                    let client_rtdb_config =
+                        citadel_user::external_services::rtdb::RtdbClientConfig {
+                            url: base_url,
+                            api_key,
+                            auth_payload: auth,
+                            expire_time,
+                            jwt,
+                        };
+                    cnac_for_sync.store_rtdb_config(client_rtdb_config); // cnac_for_sync is an Arc
+
+                    log::trace!(target: "citadel", "Successfully logged-in to RTDB + stored config inside CNAC ...");
+                };
+
+                if let ConnectMode::Fetch { .. } = connect_mode_val {
+                    log::trace!(target: "citadel", "[FETCH] complete ...");
+                    return Ok(PrimaryProcessorResult::EndSession("Fetch succeeded"));
+                }
+
+                if use_ka {
+                    let ka_ts = session.time_tracker.get_global_time_ns(); // Fresh timestamp
+                    let ka = packet_crafter::keep_alive::craft_keep_alive_packet(
+                        &ratchet, // Use original ratchet
+                        ka_ts,
+                        security_level,
+                    );
+                    Ok(PrimaryProcessorResult::ReplyToSender(ka))
                 } else {
-                    trace!(target: "citadel", "An invalid FAILURE packet was received; dropping due to invalid signature");
+                    log::warn!(target: "citadel", "Keep-alive subsystem will not be used for this session as requested");
                     Ok(PrimaryProcessorResult::Void)
                 }
             }
 
-            // Node is finally Alice. The login either failed or succeeded
-            packet_flags::cmd::aux::do_connect::SUCCESS => {
-                log::trace!(target: "citadel", "STAGE SUCCESS CONNECT PACKET");
-
-                let task = {
-                    let mut state_container = inner_mut_state!(session.state_container);
-                    let last_stage = state_container.connect_state.last_stage;
-                    let remote_uses_filesystem = header.group.get() != 0;
-                    let local_uses_file_system = matches!(
-                        session.account_manager.get_backend_type(),
-                        BackendType::Filesystem(..)
-                    );
-                    session
-                        .file_transfer_compatible
-                        .set_once(local_uses_file_system && remote_uses_filesystem);
-
-                    if last_stage == packet_flags::cmd::aux::do_connect::STAGE1 {
-                        if let Some(payload) =
-                            validation::do_connect::validate_final_status_packet(&payload)
-                        {
-                            let cnac = cnac.clone();
-                            let message = String::from_utf8(payload.message.to_vec())
-                                .unwrap_or_else(|_| String::from("Invalid message"));
-                            let kernel_ticket = session.kernel_ticket.get();
-                            let cid = ratchet.get_cid();
-
-                            state_container.connect_state.on_success();
-                            state_container.connect_state.on_connect_packet_received();
-
-                            let use_ka = state_container.keep_alive_timeout_ns != 0;
-                            let connect_mode = return_if_none!(
-                                state_container.connect_state.connect_mode,
-                                "Unable to load connect mode"
-                            );
-                            let udp_channel_rx = state_container
-                                .pre_connect_state
-                                .udp_channel_oneshot_tx
-                                .rx
-                                .take();
-
-                            let channel = state_container.init_new_c2s_virtual_connection(
-                                &cnac,
-                                kernel_ticket,
-                                header.session_cid.get(),
-                                session,
-                            );
-                            let session_security_settings = state_container
-                                .session_security_settings
-                                .expect("Should be set");
-                            std::mem::drop(state_container);
-
-                            session.session_cid.set(Some(cid)); // This makes is_provisional equal to false
-
-                            let addr = session.remote_peer;
-                            let is_personal = !session.is_server;
-
-                            // Upgrade the connect BEFORE updating the CNAC
-                            if !session
-                                .session_manager
-                                .upgrade_connection(session.remote_peer, cid)
-                            {
-                                return Ok(PrimaryProcessorResult::EndSession("Unable to upgrade from a provisional to a protected connection (Client)"));
-                            }
-
-                            log::trace!(target: "citadel", "The login to the server was a success. Welcome Message: {}", &message);
-
-                            let _post_login_object = payload.post_login_object.clone();
-                            //session.post_quantum = pqc;
-                            let cxn_type =
-                                VirtualConnectionType::LocalGroupServer { session_cid: cid };
-                            let peers = payload.peers;
-
-                            let timestamp = session.time_tracker.get_global_time_ns();
-
-                            let persistence_handler =
-                                session.account_manager.get_persistence_handler().clone();
-                            //session.session_manager.clear_provisional_tracker(session.kernel_ticket);
-                            session.state.set(SessionState::Connected);
-
-                            let success_ack = packet_crafter::do_connect::craft_success_ack(
-                                &ratchet,
-                                timestamp,
-                                security_level,
-                            );
-                            session.send_to_primary_stream(None, success_ack)?;
-
-                            session.send_to_kernel(NodeResult::ConnectSuccess(ConnectSuccess {
-                                ticket: kernel_ticket,
-                                session_cid: cid,
-                                remote_addr: addr,
-                                is_personal,
-                                v_conn_type: cxn_type,
-                                services: payload.post_login_object,
-                                welcome_message: message,
-                                channel,
-                                udp_rx_opt: udp_channel_rx,
-                                session_security_settings,
-                            }))?;
-                            //finally, if there are any mailbox items, send them to the kernel for processing
-                            if let Some(mailbox_delivery) = payload.mailbox {
-                                session.send_to_kernel(NodeResult::MailboxDelivery(
-                                    MailboxDelivery {
-                                        session_cid: cid,
-                                        ticket_opt: None,
-                                        items: mailbox_delivery,
-                                    },
-                                ))?;
-                            }
-                            // TODO: Clean this up to prevent multiple saves
-                            async move {
-                                persistence_handler
-                                    .synchronize_hyperlan_peer_list_as_client(&cnac, peers)
-                                    .await?;
-                                #[cfg(feature = "google-services")]
-                                if let (Some(rtdb_cfg), Some(jwt)) =
-                                    (_post_login_object.rtdb, _post_login_object.google_auth_jwt)
-                                {
-                                    log::trace!(target: "citadel", "Client detected RTDB config + Google Auth web token. Will login + store config to CNAC ...");
-                                    let rtdb =
-                                        citadel_user::re_exports::FirebaseRTDB::new_from_jwt(
-                                            &rtdb_cfg.url,
-                                            jwt.clone(),
-                                            rtdb_cfg.api_key.clone(),
-                                        )
-                                        .await
-                                        .map_err(|err| NetworkError::Generic(err.inner))?; // login
-
-                                    let citadel_user::re_exports::FirebaseRTDB {
-                                        base_url,
-                                        auth,
-                                        expire_time,
-                                        api_key,
-                                        jwt,
-                                        ..
-                                    } = rtdb;
-
-                                    let client_rtdb_config =
-                                        citadel_user::external_services::rtdb::RtdbClientConfig {
-                                            url: base_url,
-                                            api_key,
-                                            auth_payload: auth,
-                                            expire_time,
-                                            jwt,
-                                        };
-                                    cnac.store_rtdb_config(client_rtdb_config);
-
-                                    log::trace!(target: "citadel", "Successfully logged-in to RTDB + stored config inside CNAC ...");
-                                };
-
-                                if let ConnectMode::Fetch { .. } = connect_mode {
-                                    log::trace!(target: "citadel", "[FETCH] complete ...");
-                                    // we can end the session now. The ratchets packets have already been sent alongside the connect signal above
-                                    return Ok(PrimaryProcessorResult::EndSession(
-                                        "Fetch succeeded",
-                                    ));
-                                }
-
-                                if use_ka {
-                                    let ka = packet_crafter::keep_alive::craft_keep_alive_packet(
-                                        &ratchet,
-                                        timestamp,
-                                        security_level,
-                                    );
-                                    Ok(PrimaryProcessorResult::ReplyToSender(ka))
-                                } else {
-                                    log::warn!(target: "citadel", "Keep-alive subsystem will not be used for this session as requested");
-                                    Ok(PrimaryProcessorResult::Void)
-                                }
-                            }
-                        } else {
-                            log::error!(target: "citadel", "An invalid SUCCESS packet was received; dropping due to invalid deserialization");
-                            return Ok(PrimaryProcessorResult::Void);
-                        }
-                    } else {
-                        log::error!(target: "citadel", "An invalid SUCCESS packet was received; dropping since the last local stage was not stage 1");
-                        return Ok(PrimaryProcessorResult::Void);
-                    }
-                };
-
-                task.await
-            }
-
             packet_flags::cmd::aux::do_connect::SUCCESS_ACK => {
                 log::trace!(target: "citadel", "RECV SUCCESS_ACK");
-                if session.is_server {
-                    let signal = inner_mut_state!(session.state_container)
-                        .get_endpoint_container_mut(C2S_IDENTITY_CID)?
-                        .channel_signal
-                        .take()
-                        .ok_or(NetworkError::InternalError("Channel signal missing"))?;
-                    session.send_to_kernel(signal)?;
+                if session.is_server { // session is original Arc
+                    // This part needs to be in spawn_blocking if it modifies shared state via blocking locks
+                    let session_clone_ack = session.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let signal = inner_mut_state!(session_clone_ack.state_container)
+                            .get_endpoint_container_mut(C2S_IDENTITY_CID)?
+                            .channel_signal
+                            .take()
+                            .ok_or(NetworkError::InternalError("Channel signal missing"))?;
+                        session_clone_ack.send_to_kernel(signal) // Non-blocking channel send
+                    }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for SUCCESS_ACK failed: {}", e)))??;
+                    
                     Ok(PrimaryProcessorResult::Void)
                 } else {
                     Err(NetworkError::InvalidPacket(
@@ -470,4 +488,40 @@ pub async fn process_connect<R: Ratchet>(
     };
 
     to_concurrent_processor!(task)
+}
+
+
+// Helper function to create an owned HdpHeader from Ref.
+// This is a placeholder; actual implementation might differ based on HdpHeader's definition.
+// If HdpHeader is not easily clonable or constructible from bytes, this part needs more thought.
+// For now, assuming it can be reconstructed or relevant parts extracted and owned.
+fn parsed_header_from_ref<T: Copy>(header_ref: &Ref<&[u8], T>) -> T {
+    // This is a simplification. In reality, you'd parse `header_ref.bytes()`
+    // into an owned HdpHeader struct or extract necessary fields.
+    // If HdpHeader is large and not easily made 'static or Send, this is complex.
+    // For the purpose of this fix, we assume an owned version can be made.
+    **header_ref // This works if T is Copy and Ref derefs to T.
+                 // If HdpHeader is not Copy, you'd do:
+                 // HdpHeader::from_bytes(header_ref.bytes()).unwrap() or similar.
+}
+
+// Extend futures::FutureExt for .then combinator like syntax if not available
+trait FutureExtThen: Sized + futures::Future {
+    fn then<Fut, F>(self, f: F) -> futures::future::Then<Self, Fut, F>
+    where
+        Fut: futures::Future,
+        F: FnOnce(Self::Output) -> Fut;
+}
+
+impl<T> FutureExtThen for T
+where
+    T: Sized + futures::Future,
+{
+    fn then<Fut, F>(self, f: F) -> futures::future::Then<Self, Fut, F>
+    where
+        Fut: futures::Future,
+        F: FnOnce(Self::Output) -> Fut,
+    {
+        futures::FutureExt::then(self, f)
+    }
 }

--- a/citadel_proto/src/proto/packet_processor/raw_primary_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/raw_primary_packet.rs
@@ -51,127 +51,140 @@ use crate::error::NetworkError;
     skip_all,
     ret,
     err,
-    fields(session_cid=this_session_cid, is_server=session.is_server, packet_len=packet.len())
+    fields(session_cid=this_session_cid, is_server=session.is_server, packet_len=input_packet.len())
 ))]
 pub async fn process_raw_packet<R: Ratchet>(
     this_session_cid: Option<u64>,
     session: &CitadelSession<R>,
     remote_peer: SocketAddr,
     local_primary_port: u16,
-    packet: BytesMut,
+    input_packet: BytesMut, // Renamed to avoid conflict
 ) -> Result<PrimaryProcessorResult, NetworkError> {
-    //return_if_none!(header_obfuscator.on_packet_received(&mut packet));
-    let packet = HdpPacket::new_recv(packet, remote_peer, local_primary_port);
-    if packet.parse().is_none() {
-        log::warn!(target: "citadel", "Unable to parse packet {:?} | Len: {}", packet.as_bytes(), packet.get_length());
-        return Ok(PrimaryProcessorResult::Void);
-    }
+    // It's important that HdpPacket construction and initial parsing are quick and don't block.
+    // Assuming HdpPacket::new_recv and .parse() are efficient.
+    let temp_hdp_packet = HdpPacket::new_recv(input_packet.clone(), remote_peer, local_primary_port);
+    let parsed_header = match temp_hdp_packet.parse() {
+        Some(h) => h.0, // Get the Header directly
+        None => {
+            log::warn!(target: "citadel", "Unable to parse packet {:?} | Len: {}", input_packet.as_bytes(), input_packet.len());
+            return Ok(PrimaryProcessorResult::Void);
+        }
+    };
 
-    log::trace!(target: "citadel", "RECV Raw packet: {:?}", &packet.parse().unwrap().0);
-    let (header, _payload) = return_if_none!(packet.parse(), "Unable to parse packet");
+    log::trace!(target: "citadel", "RECV Raw packet: {:?}", &parsed_header);
+    
+    let target_cid = parsed_header.target_cid.get();
+    let cmd_primary = parsed_header.cmd_primary;
+    let cmd_aux = parsed_header.cmd_aux;
+    let header_entropy_bank_vers = parsed_header.entropy_bank_version.get();
+    let header_session_cid = parsed_header.session_cid.get();
 
-    let target_cid = header.target_cid.get();
-    let mut endpoint_cid_info = None;
-    // if proxying/p2p is involved, then the target_cid != 0
-    let cmd_primary = header.cmd_primary;
-    let cmd_aux = header.cmd_aux;
-    let header_entropy_bank_vers = header.entropy_bank_version.get();
+    // Clone necessary data for spawn_blocking
+    let session_clone_for_check_proxy = session.clone();
+    // HdpPacket should be Send. BytesMut is Send.
+    let packet_for_check_proxy = input_packet; 
 
-    match check_proxy(
-        this_session_cid,
-        header.cmd_primary,
-        header.cmd_aux,
-        header.session_cid.get(),
-        target_cid,
-        session,
-        &mut endpoint_cid_info,
-        ReceivePortType::OrderedReliable,
-        packet,
-    ) {
-        Some(packet) => match cmd_primary {
+    let (packet_after_proxy_check_opt, endpoint_cid_info_from_blocking) = 
+        tokio::task::spawn_blocking(move || {
+            let mut endpoint_cid_info_blocking: Option<(u64,u64)> = None;
+            // Reconstruct HdpPacket inside blocking task if it's not Send, or if original packet is modified by parse()
+            // For now, assuming packet_for_check_proxy (BytesMut) is sufficient to reconstruct or HdpPacket is Send
+            let hdp_packet_for_check_proxy = HdpPacket::new_recv(packet_for_check_proxy, remote_peer, local_primary_port);
+
+            let result_packet = check_proxy(
+                this_session_cid,
+                cmd_primary, // Use pre-parsed cmd_primary
+                cmd_aux,     // Use pre-parsed cmd_aux
+                header_session_cid, // Use pre-parsed header_session_cid
+                target_cid,  // Use pre-parsed target_cid
+                &session_clone_for_check_proxy,
+                &mut endpoint_cid_info_blocking,
+                ReceivePortType::OrderedReliable,
+                hdp_packet_for_check_proxy, // Pass the HdpPacket
+            );
+            (result_packet, endpoint_cid_info_blocking)
+        }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for check_proxy failed: {}", e)))?;
+
+    if let Some(packet_to_process) = packet_after_proxy_check_opt {
+        let final_endpoint_cid_info = endpoint_cid_info_from_blocking;
+
+        match cmd_primary {
             packet_flags::cmd::primary::DO_REGISTER => {
-                super::register_packet::process_register(session, packet, remote_peer).await
+                super::register_packet::process_register(session, packet_to_process, remote_peer).await
             }
 
             packet_flags::cmd::primary::DO_CONNECT => {
-                super::connect_packet::process_connect(session, packet, header_entropy_bank_vers)
-                    .await
+                super::connect_packet::process_connect(session, packet_to_process, header_entropy_bank_vers).await
             }
 
             packet_flags::cmd::primary::KEEP_ALIVE => {
-                super::keep_alive_packet::process_keep_alive(
-                    session,
-                    packet,
-                    header_entropy_bank_vers,
-                )
-                .await
+                super::keep_alive_packet::process_keep_alive(session, packet_to_process, header_entropy_bank_vers).await
             }
 
             packet_flags::cmd::primary::GROUP_PACKET => {
-                super::primary_group_packet::process_primary_packet(
-                    session,
-                    cmd_aux,
-                    packet,
-                    endpoint_cid_info,
-                )
+                // This was originally synchronous. Wrap in spawn_blocking.
+                let session_clone_group = session.clone();
+                tokio::task::spawn_blocking(move || {
+                    super::primary_group_packet::process_primary_packet(
+                        &session_clone_group,
+                        cmd_aux,
+                        packet_to_process,
+                        final_endpoint_cid_info,
+                    )
+                }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for group_packet failed: {}", e)))?
             }
 
             packet_flags::cmd::primary::DO_DISCONNECT => {
-                super::disconnect_packet::process_disconnect(
-                    session,
-                    packet,
-                    header_entropy_bank_vers,
-                )
-                .await
+                super::disconnect_packet::process_disconnect(session, packet_to_process, header_entropy_bank_vers).await
             }
 
             packet_flags::cmd::primary::DO_DEREGISTER => {
-                super::deregister_packet::process_deregister(
-                    session,
-                    packet,
-                    header_entropy_bank_vers,
-                )
-                .await
+                super::deregister_packet::process_deregister(session, packet_to_process, header_entropy_bank_vers).await
             }
 
             packet_flags::cmd::primary::DO_PRE_CONNECT => {
-                super::preconnect_packet::process_preconnect(
-                    session,
-                    packet,
-                    header_entropy_bank_vers,
-                )
-                .await
+                super::preconnect_packet::process_preconnect(session, packet_to_process, header_entropy_bank_vers).await
             }
 
             packet_flags::cmd::primary::PEER_CMD => {
                 peer_cmd_packet::process_peer_cmd(
                     session,
                     cmd_aux,
-                    packet,
+                    packet_to_process,
                     header_entropy_bank_vers,
-                    endpoint_cid_info,
-                )
-                .await
+                    final_endpoint_cid_info,
+                ).await
             }
 
             packet_flags::cmd::primary::FILE => {
-                super::file_packet::process_file_packet(session, packet, endpoint_cid_info)
+                // This was originally synchronous. Wrap in spawn_blocking.
+                let session_clone_file = session.clone();
+                tokio::task::spawn_blocking(move || {
+                    super::file_packet::process_file_packet(&session_clone_file, packet_to_process, final_endpoint_cid_info)
+                }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for file_packet failed: {}", e)))?
             }
 
-            packet_flags::cmd::primary::HOLE_PUNCH => super::hole_punch::process_hole_punch(
-                session,
-                packet,
-                header_entropy_bank_vers,
-                endpoint_cid_info,
-            ),
+            packet_flags::cmd::primary::HOLE_PUNCH => {
+                // This was originally synchronous. Wrap in spawn_blocking.
+                let session_clone_hole_punch = session.clone();
+                tokio::task::spawn_blocking(move || {
+                    super::hole_punch::process_hole_punch(
+                        &session_clone_hole_punch,
+                        packet_to_process,
+                        header_entropy_bank_vers,
+                        final_endpoint_cid_info,
+                    )
+                }).await.map_err(|e| NetworkError::Generic(format!("spawn_blocking for hole_punch failed: {}", e)))?
+            }
 
             _ => {
                 warn!(target: "citadel", "The primary port received an invalid packet command. Dropping");
                 Ok(PrimaryProcessorResult::Void)
             }
-        },
-
-        None => Ok(PrimaryProcessorResult::Void),
+        }
+    } else {
+        // Packet was proxied
+        Ok(PrimaryProcessorResult::Void)
     }
 }
 
@@ -223,10 +236,10 @@ pub(crate) fn check_proxy<R: Ratchet>(
         // [*] in the case of proxying, it should only be done after a connection is well established
         // This would imply that the implicated cid is established in the HdpSession. As such, if the implicated CID is None,
         // then simply let normal logic below continue
-        if let Some(this_session_cid) = this_session_cid {
+        if let Some(this_session_cid_val) = this_session_cid {
             // this implies there is at least a connection between hLAN client and hLAN server, but we don't know which is which
-            if this_session_cid != target_cid {
-                log::trace!(target: "citadel", "Proxying {}:{} packet from {} to {}", cmd_primary, cmd_aux, this_session_cid, target_cid);
+            if this_session_cid_val != target_cid {
+                log::trace!(target: "citadel", "Proxying {}:{} packet from {} to {}", cmd_primary, cmd_aux, this_session_cid_val, target_cid);
                 // Proxy will only occur if there exists a virtual connection, in which case, we get the TcpSender (since these are primary packets)
 
                 let mut state_container = inner_mut_state!(session.state_container);


### PR DESCRIPTION
This commit addresses multiple instances in the `citadel_proto` crate where blocking operations were being performed directly within asynchronous functions, potentially stalling Tokio executor threads. Such blocking can lead to performance degradation, reduced responsiveness, and even apparent hangs under load.

The primary fix involves wrapping these blocking sections of code with `tokio::task::spawn_blocking`. This offloads the synchronous work (CPU-intensive cryptography, synchronous lock acquisitions on `citadel_io::RwLock`, etc.) to Tokio's blocking-aware thread pool, allowing the async executor threads to remain unblocked and continue polling other tasks.

Key areas refactored include:

- **`citadel_proto::proto::session`**:
    - Parts of `async fn handle_zero_state`, particularly the `NeedsRegister` branch involving cryptographic operations.
    - The initial setup phase of `async fn execute_queue_worker`.

- **`citadel_proto::proto::packet_processor::raw_primary_packet`**:
    - Calls to synchronous handlers like `check_proxy` and other packet processing functions from `async fn process_raw_packet`.

- **`citadel_proto::proto::packet_processor::register_packet`**:
    - CPU-intensive cryptographic operations during various registration stages (STAGE0, STAGE1).
    - Synchronous validation calls (`validate_stage2`, `validate_success`) that involve cryptographic computations.
    - Synchronous `session.shutdown()` and `session.begin_connect()` calls.

- **`citadel_proto::proto::packet_processor::connect_packet`**:
    - Initial synchronous prefix involving AEAD validation and state reads.
    - Synchronous state updates and operations within various connection stages (STAGE0, FAILURE, SUCCESS, SUCCESS_ACK).

These changes are expected to improve the overall stability and performance of applications using `citadel_proto`, especially under concurrent load, by ensuring that Tokio's async runtime is not inappropriately blocked.