### PR TITLE
Add compiling examples to the protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,3 +371,40 @@ This project is dual-licensed for maximum permissibility under:
 
 - [👨‍💻 Thomas Braun](https://thomaspbraun.com) - Inventor and Core Developer
 - [👨‍💻 Donovan Tjemmes](https://github.com/Tjemmmic) - Developer
+
+## 🎯 Examples
+
+The repository ships with a rich collection of ready-to-run example binaries that showcase the Citadel Protocol in both **client-server (C2S)** and **peer-to-peer (P2P)** scenarios. All of the examples live in the dedicated `citadel-examples` crate located at `example-library/`.
+
+### 🏗️ Compiling **all** examples
+
+From the repository root run:
+
+```bash
+# Debug build
+cargo build -p citadel-examples --examples
+
+# Release build (optimised)
+cargo build -p citadel-examples --examples --release
+```
+
+The flag `--examples` tells Cargo to build every `[[example]]` target declared in `example-library/Cargo.toml`.
+
+### 🔬 Compiling a **single** example
+
+If you only need one binary you can compile it individually:
+
+```bash
+# Build the basic server example
+cargo build -p citadel-examples --example server_basic
+```
+
+### ▶️ Running an example
+
+`cargo run` will compile (if necessary) and launch a chosen example in a single step. For example, to start the basic server shown in the documentation:
+
+```bash
+cargo run -p citadel-examples --example server_basic
+```
+
+A convenient walkthrough for every example together with the required environment variables can be found in the dedicated [examples README](./example-library/README.md).


### PR DESCRIPTION
A new "🎯 Examples" section was added to `README.md` to provide comprehensive guidance on the project's examples.

This section details that:
*   Examples reside in the `citadel-examples` crate within `example-library/`.
*   Commands are provided for:
    *   Compiling all examples using `cargo build -p citadel-examples --examples` for both debug and release builds.
    *   Compiling a single example with `cargo build -p citadel-examples --example <name>`.
    *   Running an example using `cargo run -p citadel-examples --example <name>`.
*   The use of the `--examples` flag is clarified.
*   A link is provided to `example-library/README.md` for detailed walkthroughs and environment variables.

This addition fills a gap in the main `README.md` by providing clear instructions on how to compile and run the project's examples.