### PR TITLE
feat(wire): ICE-style server-reflexive candidates for UDP hole-punch

### DIFF
--- a/citadel_wire/src/standard/nat_identification.rs
+++ b/citadel_wire/src/standard/nat_identification.rs
@@ -463,6 +463,102 @@ mod native {
                 )),
             }
         }
+
+        /// STUN-probes the *actual* hole-punch socket to learn its server-reflexive
+        /// (external) address — the exact mapping the remote peer will target.
+        ///
+        /// Unlike [`NatType::identify`], which models the NAT from throwaway sockets and
+        /// then *predicts* an external address, this observes the real mapping. That makes
+        /// traversal succeed for endpoint-independent NATs that do not preserve the port
+        /// (where prediction is impossible). The socket is probed un-connected, so it stays
+        /// usable for the subsequent hole-punch barrage.
+        ///
+        /// Returns `None` when no server answers — the caller then relies solely on the
+        /// predicted bands, preserving prior behavior. IPv6 sockets are skipped: IPv6 is
+        /// typically un-NATed and is already covered by the `ip_info`-derived band.
+        pub async fn get_reflexive_addr(
+            socket: &UdpSocket,
+            stun_servers: Option<&[String]>,
+        ) -> Option<SocketAddr> {
+            if cfg!(feature = "localhost-testing") {
+                return None;
+            }
+
+            // The probe socket is IPv4; an IPv6 socket cannot reach the IPv4 STUN servers.
+            if !socket.local_addr().ok()?.is_ipv4() {
+                return None;
+            }
+
+            let owned_default;
+            let servers: &[String] = match stun_servers {
+                Some(servers) if !servers.is_empty() => servers,
+                _ => {
+                    owned_default = STUN_SERVERS
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>();
+                    &owned_default
+                }
+            };
+
+            for server in servers {
+                if let Some(addr) = stun_probe_socket(socket, server).await {
+                    return Some(addr);
+                }
+            }
+
+            None
+        }
+    }
+
+    /// Sends a single STUN BINDING request from `socket` to `server` and returns the
+    /// observed XOR-mapped (external) address. IPv4 only; bounded by a short timeout.
+    async fn stun_probe_socket(socket: &UdpSocket, server: &str) -> Option<SocketAddr> {
+        // Resolve to an IPv4 endpoint (the probe socket is IPv4).
+        let server_addr = citadel_io::tokio::net::lookup_host(server)
+            .await
+            .ok()?
+            .find(SocketAddr::is_ipv4)?;
+
+        let mut request = Message::new();
+        request
+            .build(&[
+                Box::<stun::agent::TransactionId>::default(),
+                Box::new(BINDING_REQUEST),
+            ])
+            .ok()?;
+        let transaction_id = request.transaction_id;
+
+        socket.send_to(&request.raw, server_addr).await.ok()?;
+
+        let recv = async {
+            let mut buf = [0u8; 256];
+            loop {
+                let (len, from) = socket.recv_from(&mut buf).await.ok()?;
+                if from != server_addr {
+                    // Not the STUN server (e.g. a stray/early hole-punch packet); ignore.
+                    continue;
+                }
+
+                let mut response = Message::new();
+                response.raw = buf[..len].to_vec();
+                if response.decode().is_err() || response.transaction_id != transaction_id {
+                    continue;
+                }
+
+                let mut xor_addr = XorMappedAddress::default();
+                if xor_addr.get_from(&response).is_err() {
+                    continue;
+                }
+
+                return Some(SocketAddr::new(xor_addr.ip, xor_addr.port));
+            }
+        };
+
+        citadel_io::time::timeout(Duration::from_millis(1500), recv)
+            .await
+            .ok()
+            .flatten()
     }
 
     #[cfg_attr(

--- a/citadel_wire/src/standard/nat_identification.rs
+++ b/citadel_wire/src/standard/nat_identification.rs
@@ -476,14 +476,14 @@ mod native {
         /// Returns `None` when no server answers — the caller then relies solely on the
         /// predicted bands, preserving prior behavior. IPv6 sockets are skipped: IPv6 is
         /// typically un-NATed and is already covered by the `ip_info`-derived band.
+        ///
+        /// The caller decides *when* to probe (the hole-punch driver skips this under
+        /// `localhost-testing`, where there are no real STUN servers); this function itself
+        /// probes unconditionally so it stays unit-testable against a local STUN responder.
         pub async fn get_reflexive_addr(
             socket: &UdpSocket,
             stun_servers: Option<&[String]>,
         ) -> Option<SocketAddr> {
-            if cfg!(feature = "localhost-testing") {
-                return None;
-            }
-
             // The probe socket is IPv4; an IPv6 socket cannot reach the IPv4 STUN servers.
             if !socket.local_addr().ok()?.is_ipv4() {
                 return None;
@@ -713,6 +713,69 @@ mod tests {
         let nat_type = NatType::identify(None).await.unwrap();
         let traversal_type = nat_type.traversal_type_required();
         log::trace!(target: "citadel", "NAT Type: {nat_type:?} | Reaching this node will require: {traversal_type:?} NAT traversal | Hypothetical connect scenario");
+    }
+
+    /// Exercises `get_reflexive_addr` (and `stun_probe_socket`) end-to-end against a local
+    /// fake STUN responder over loopback — no real network — so the observe-the-real-mapping
+    /// path is covered even though the hole-punch driver gates it off under localhost-testing.
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn get_reflexive_addr_parses_local_stun_response() {
+        use citadel_io::tokio::net::UdpSocket;
+        use stun::message::{Message, BINDING_SUCCESS};
+        use stun::xoraddr::XorMappedAddress;
+
+        // The external address the fake STUN server will report back.
+        let mapped = SocketAddr::from_str("203.0.113.9:51234").unwrap();
+
+        // Fake STUN server: echoes the request's transaction id in a BINDING_SUCCESS carrying
+        // an XOR-MAPPED-ADDRESS. `build()` clears attributes but preserves `transaction_id`,
+        // and `XorMappedAddress` encodes against it, so the client can match and decode.
+        let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = server.local_addr().unwrap();
+        let server_task = citadel_io::tokio::task::spawn(async move {
+            let mut buf = [0u8; 256];
+            let (len, from) = server.recv_from(&mut buf).await.unwrap();
+            let mut request = Message::new();
+            request.raw = buf[..len].to_vec();
+            request.decode().unwrap();
+
+            let mut response = Message::new();
+            response.transaction_id = request.transaction_id;
+            response
+                .build(&[
+                    Box::new(BINDING_SUCCESS),
+                    Box::new(XorMappedAddress {
+                        ip: mapped.ip(),
+                        port: mapped.port(),
+                    }),
+                ])
+                .unwrap();
+            server.send_to(&response.raw, from).await.unwrap();
+        });
+
+        let client = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let observed = NatType::get_reflexive_addr(&client, Some(&[server_addr.to_string()])).await;
+        server_task.await.unwrap();
+
+        assert_eq!(
+            observed,
+            Some(mapped),
+            "reflexive addr must match the STUN-reported mapping"
+        );
+    }
+
+    /// An IPv6 probe socket is skipped (cannot reach the IPv4 STUN servers) and returns None
+    /// without any network I/O.
+    #[cfg(not(target_family = "wasm"))]
+    #[tokio::test]
+    async fn get_reflexive_addr_skips_ipv6_socket() {
+        let socket = citadel_io::tokio::net::UdpSocket::bind("[::1]:0")
+            .await
+            .unwrap();
+        let observed =
+            NatType::get_reflexive_addr(&socket, Some(&["127.0.0.1:3478".to_string()])).await;
+        assert_eq!(observed, None);
     }
 
     #[test]

--- a/citadel_wire/src/udp_traversal/hole_punch_config.rs
+++ b/citadel_wire/src/udp_traversal/hole_punch_config.rs
@@ -15,7 +15,7 @@
 //!     let socket = UdpSocket::bind("0.0.0.0:0").await?;
 //!     let target_addr = "127.0.0.1:8080".parse::<SocketAddr>().unwrap();
 //!     let peer_nat = NatType::identify(None).await?;
-//!     let config = HolePunchConfig::new(&peer_nat, &[target_addr], vec![socket]);
+//!     let config = HolePunchConfig::new(&peer_nat, &[target_addr], &[], vec![socket]);
 //!     Ok(())
 //! }
 //! ```
@@ -51,6 +51,7 @@
 //!     let config = HolePunchConfig::new(
 //!         &peer_nat,
 //!         &[peer_addr],
+//!         &[],
 //!         vec![socket]
 //!     );
 //!     
@@ -135,9 +136,15 @@ mod native {
     }
 
     impl HolePunchConfig {
+        /// `peer_reflexive_addrs` are the peer's *observed* server-reflexive (external)
+        /// addresses — see [`NatType::get_reflexive_addr`]. They are exact (not predicted),
+        /// so they are added as candidates to every band set, letting traversal succeed for
+        /// endpoint-independent NATs whose port the predictive model cannot infer.
+        /// Version-incompatible entries are filtered downstream per local socket.
         pub fn new(
             peer_nat: &NatType,
             peer_internal_addrs: &[SocketAddr],
+            peer_reflexive_addrs: &[SocketAddr],
             local_sockets: Vec<UdpSocket>,
         ) -> Self {
             assert_eq!(peer_internal_addrs.len(), local_sockets.len());
@@ -158,6 +165,12 @@ mod native {
                         anticipated_ports: vec![peer_internal_addr.port()],
                     }]
                 };
+
+                // ICE-style server-reflexive candidates: exact, observed external addrs.
+                bands.extend(peer_reflexive_addrs.iter().map(|addr| AddrBand {
+                    necessary_ip: addr.ip(),
+                    anticipated_ports: vec![addr.port()],
+                }));
 
                 bands.extend(get_localhost_bands(peer_internal_addr));
 
@@ -185,3 +198,34 @@ mod native {
 
 #[cfg(not(target_family = "wasm"))]
 pub use native::HolePunchConfig;
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::HolePunchConfig;
+    use crate::nat_identification::NatType;
+    use citadel_io::tokio;
+    use std::net::SocketAddr;
+    use std::str::FromStr;
+
+    /// An observed server-reflexive (external) address must become a ping candidate even
+    /// when the predictive NAT model yields nothing — this is the whole point of probing
+    /// the real socket for endpoint-independent NATs that randomize the external port.
+    #[tokio::test]
+    async fn reflexive_addr_becomes_candidate() {
+        let socket = citadel_io::tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        let peer_internal = SocketAddr::from_str("192.168.1.50:40000").unwrap();
+        let reflexive = SocketAddr::from_str("203.0.113.7:55555").unwrap();
+
+        // Default NatType is Unpredictable -> predict() returns None (no model bands).
+        let nat = NatType::default();
+        let config = HolePunchConfig::new(&nat, &[peer_internal], &[reflexive], vec![socket]);
+
+        let candidates: Vec<SocketAddr> = config.into_iter().flatten().collect();
+        assert!(
+            candidates.contains(&reflexive),
+            "observed reflexive candidate must be pinged, got: {candidates:?}"
+        );
+    }
+}

--- a/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
+++ b/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
@@ -272,6 +272,12 @@ async fn probe_reflexive_addrs(
     sockets: &[UdpSocket],
     stun_servers: Option<&[String]>,
 ) -> Vec<SocketAddr> {
+    // Under localhost-testing there are no reachable STUN servers; skip probing entirely
+    // (the configured/default servers would be unreachable and just add latency).
+    if cfg!(feature = "localhost-testing") {
+        return Vec::new();
+    }
+
     let probes = sockets
         .iter()
         .map(|socket| NatType::get_reflexive_addr(socket, stun_servers));

--- a/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
+++ b/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
@@ -40,9 +40,22 @@ use futures::Future;
 use netbeam::reliable_conn::ReliableOrderedStreamToTargetExt;
 use netbeam::sync::network_endpoint::NetworkEndpoint;
 use netbeam::sync::subscription::Subscribable;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
+
+/// The address candidates each peer publishes during the synchronized pre-process exchange.
+/// `internal_bind_addrs` are the local bind addresses (loopback/same-LAN reachability);
+/// `reflexive_addrs` are the *observed* server-reflexive (external) addresses of the actual
+/// hole-punch sockets (ICE-style srflx candidates). Reflexive addrs are exact rather than
+/// predicted, so they enable direct traversal for NATs the predictive model cannot infer.
+#[derive(Serialize, Deserialize)]
+struct HolePunchCandidates {
+    internal_bind_addrs: Vec<SocketAddr>,
+    reflexive_addrs: Vec<SocketAddr>,
+}
 
 pub struct UdpHolePuncher<'a> {
     driver: Pin<Box<dyn Future<Output = Result<HolePunchedUdpSocket, anyhow::Error>> + Send + 'a>>,
@@ -144,7 +157,7 @@ async fn driver_inner(
 
     // Step 2: NAT type identification
     log::trace!(target: "citadel", "[driver] Step 2: Identifying local NAT type...");
-    let local_nat_type = match NatType::identify(stun_servers).await {
+    let local_nat_type = match NatType::identify(stun_servers.clone()).await {
         Ok(nat) => {
             log::trace!(target: "citadel", "[driver] Step 2: NAT identification successful: {nat:?}");
             nat
@@ -185,24 +198,41 @@ async fn driver_inner(
         sockets.push(additional_socket);
     }
 
-    // Step 4: Exchange internal bind ports, synchronizing the beginning of the hole punch process
-    log::trace!(target: "citadel", "[driver] Step 4: Exchanging internal bind addresses...");
-    let peer_internal_bind_addrs = match conn.sync_exchange_payload(internal_addresses).await {
-        Ok(addrs) => {
-            log::trace!(target: "citadel", "[driver] Step 4: Sync exchange successful, peer addrs: {addrs:?}");
-            addrs
+    // Step 3b: ICE-style — observe the *actual* external mapping of each hole-punch socket
+    // via STUN, rather than relying solely on the predictive NAT model. This lets traversal
+    // succeed for endpoint-independent NATs that randomize the external port. Failure to probe
+    // is non-fatal: we simply fall back to the predicted bands.
+    let local_reflexive_addrs = probe_reflexive_addrs(&sockets, stun_servers.as_deref()).await;
+    log::info!(target: "citadel", "[driver] Local reflexive (srflx) addrs: {local_reflexive_addrs:?}");
+
+    // Step 4: Exchange address candidates, synchronizing the beginning of the hole punch process
+    log::trace!(target: "citadel", "[driver] Step 4: Exchanging address candidates...");
+    let local_candidates = HolePunchCandidates {
+        internal_bind_addrs: internal_addresses,
+        reflexive_addrs: local_reflexive_addrs,
+    };
+    let peer_candidates = match conn.sync_exchange_payload(local_candidates).await {
+        Ok(candidates) => {
+            log::trace!(target: "citadel", "[driver] Step 4: Sync exchange successful, peer internal: {:?}, peer reflexive: {:?}", candidates.internal_bind_addrs, candidates.reflexive_addrs);
+            candidates
         }
         Err(e) => {
             log::error!(target: "citadel", "[driver] Step 4 FAILED: Sync exchange error: {e:?}");
             return Err(e);
         }
     };
+    let peer_internal_bind_addrs = peer_candidates.internal_bind_addrs;
     log::info!(target: "citadel", "\n~~~~~~~~~~~~\n [driver] Local NAT type: {local_nat_type:?}\n Peer NAT type: {peer_nat_type:?}");
     log::info!(target: "citadel", "[driver] Local internal bind addr: {internal_bind_addr_optimal:?}\nPeer internal bind addr: {peer_internal_bind_addrs:?}");
     log::info!(target: "citadel", "\n~~~~~~~~~~~~\n");
     // the next functions takes everything insofar obtained into account without causing collisions with any existing
     // connections (e.g., no conflicts with the primary stream existing in conn)
-    let hole_punch_config = HolePunchConfig::new(peer_nat_type, &peer_internal_bind_addrs, sockets);
+    let hole_punch_config = HolePunchConfig::new(
+        peer_nat_type,
+        &peer_internal_bind_addrs,
+        &peer_candidates.reflexive_addrs,
+        sockets,
+    );
 
     // Step 5: Execute DualStackUdpHolePuncher
     let conn = conn.clone();
@@ -233,6 +263,23 @@ async fn driver_inner(
             "**HOLE-PUNCH-ERR**: {err:?} | local_nat_type: {local_nat_type:?} | peer_nat_type: {peer_nat_type:?}",
         ))
     })
+}
+
+/// Concurrently STUN-probes each hole-punch socket for its server-reflexive (external)
+/// address. Probes run in parallel and degrade gracefully: any socket that fails to obtain
+/// a reflexive address (e.g. IPv6, or no STUN server reachable) is simply omitted.
+async fn probe_reflexive_addrs(
+    sockets: &[UdpSocket],
+    stun_servers: Option<&[String]>,
+) -> Vec<SocketAddr> {
+    let probes = sockets
+        .iter()
+        .map(|socket| NatType::get_reflexive_addr(socket, stun_servers));
+    futures::future::join_all(probes)
+        .await
+        .into_iter()
+        .flatten()
+        .collect()
 }
 
 /// since the NAT traversal process always ensures that both public-facing and loopback


### PR DESCRIPTION
## Summary

The custom NAT traversal previously **predicted** each hole-punch socket's external address from a model built off three throwaway STUN sockets (`NatType::predict`). That only holds for **port-preserving / constant-offset** endpoint-independent NATs. For the common **EIM-but-port-randomizing** routers, the model collapses to `Unpredictable` and the connection needlessly falls back to relay — even though a standard ICE agent would traverse it directly, because ICE STUNs the *actual* candidate socket rather than guessing its mapping.

This PR closes that gap by **observing** the real mapping (ICE `srflx` candidate) and exchanging it, with the predictive model retained as fallback.

## Changes

- **`NatType::get_reflexive_addr`** (+ private `stun_probe_socket`) — STUNs the actual hole-punch socket **un-connected** (manual STUN marshalling, so the socket stays usable for the subsequent barrage). IPv4-only (IPv6 is typically un-NATed and already covered by the `ip_info` band). Fails open to `None`.
- **`HolePunchConfig::new`** — accepts the peer's observed reflexive addrs and adds them as exact candidate bands; version-incompatible entries are filtered downstream per local socket.
- **`driver_inner`** — probes local sockets concurrently and the synchronized Step-4 exchange now carries `HolePunchCandidates { internal_bind_addrs, reflexive_addrs }` instead of a bare `Vec<SocketAddr>`.

## Why it's safe / backward-compatible

- Reflexive probing is gated off under `localhost-testing` (like `identify`) and **fails open** — absent srflx, behavior is byte-for-byte the prior predicted-band path.
- For symmetric NATs the srflx is simply wrong and gets pruned/ignored — **pure upside, no regression**.
- Both peers run identical code, so the new exchange struct is self-consistent on the wire.

## Verification

- `cargo build` + `clippy` clean — default **and** `localhost-testing`; `citadel_proto` (downstream) builds clean.
- `cargo fmt --check` clean.
- Doctests pass; new unit test `reflexive_addr_becomes_candidate` passes.
- All 4 end-to-end `test_dual_hole_puncher*` tests pass under `localhost-testing`.

## Follow-ups (out of scope, from the same audit)

- Widen the barrage from `count=2` to retransmit across the full receive window (loss robustness).
- RFC 5780 filtering-behavior tests.
- Wire `TurnServerConfig` into an actual native relay (`TraversalTypeRequired::TURN` is advisory only on native today).