### PR TITLE
fix(user): keep the local-only CID-0 account across backend reloads

### DIFF
--- a/citadel_user/src/account_manager.rs
+++ b/citadel_user/src/account_manager.rs
@@ -309,6 +309,18 @@ impl<R: Ratchet, Fcm: Ratchet> AccountManager<R, Fcm> {
     /// it is highly advisable to independently use and store an encryption key outside of the local program such
     /// that all stored data is encrypted in case of attack. This function needs to be used with caution.
     async fn setup_local_only_account(&self) -> Result<(), AccountError> {
+        // Idempotent on purpose. `AccountManager::new` runs this on every
+        // startup, *after* the backend has loaded any persisted accounts. The
+        // local-only (CID 0) account doubles as the local node's persistent
+        // store: callers stash arbitrary data in its `byte_map` via the CID-0
+        // KV path (e.g. server-global, account-independent metadata).
+        // Unconditionally re-creating a fresh CID-0 CNAC here would `save_cnac`
+        // an empty `byte_map` over the one just loaded from disk, wiping that
+        // data on every restart. Only create the account when it is absent.
+        if self.persistence_handler.cid_is_registered(0).await? {
+            return Ok(());
+        }
+
         // Setup mock CNAC
         let cnac = ClientNetworkAccount::<R, Fcm>::new_from_network_personal(
             0,

--- a/citadel_user/tests/primary.rs
+++ b/citadel_user/tests/primary.rs
@@ -663,12 +663,14 @@ mod tests {
             // the entire (possibly shared) backend and clobber other tests. Doing
             // it up front also clears anything an earlier aborted run left behind,
             // so the Session 1 "first write returns None" assertion is reliable.
+            // Best-effort: the result is dropped without `?` so a cleanup error
+            // never fails the test on its own.
             {
                 let pers = acc_mgr(backend.clone())
                     .await
                     .get_persistence_handler()
                     .clone();
-                let _ = pers.remove_byte_map_values_by_key(0, 0, key).await?;
+                let _ = pers.remove_byte_map_values_by_key(0, 0, key).await;
             }
 
             // Session 1: write two sub_keys under CID 0.
@@ -708,10 +710,11 @@ mod tests {
             let s3_one = pers3.get_byte_map_value(0, 0, key, "sub_one").await?;
             let s3_two = pers3.get_byte_map_value(0, 0, key, "sub_two").await?;
 
-            // Targeted cleanup of only this test's key, before any assertion can
-            // panic. A later run's up-front cleanup covers the case where an op
-            // above returns Err and skips this line.
-            let _ = pers3.remove_byte_map_values_by_key(0, 0, key).await?;
+            // Targeted, best-effort cleanup of only this test's key, run before
+            // any assertion can panic (so a failing assert never leaves data
+            // behind). If an op above returned Err and skipped this, a later
+            // run's up-front cleanup covers it.
+            let _ = pers3.remove_byte_map_values_by_key(0, 0, key).await;
 
             assert!(
                 s1_one.is_none() && s1_two.is_none(),

--- a/citadel_user/tests/primary.rs
+++ b/citadel_user/tests/primary.rs
@@ -646,6 +646,11 @@ mod tests {
 
         let value = Vec::from("local-only-persisted");
         let sibling = Vec::from("sibling-value");
+        // A key unique to this test. CID 0 is a shared namespace (other tests use
+        // it too, e.g. `test_byte_map_local`'s "thekey"), so a distinct key keeps
+        // this test's data isolated even when the suite runs concurrently against
+        // a shared backend.
+        let key = "reload_test_local_only";
 
         for backend in server_backends() {
             if matches!(backend, BackendType::InMemory) {
@@ -653,9 +658,18 @@ mod tests {
             }
             log::info!(target: "citadel", "Reload test on backend: {backend:?}");
 
-            // Capture every read/write first and `purge` before asserting, so a
-            // failed expectation can never skip cleanup and leave CID-0 state on
-            // a shared backend (e.g. SQL/Redis) to contaminate a later run.
+            // Cleanup, here and at the end, removes ONLY this test's own key via
+            // `remove_byte_map_values_by_key` — never `purge()`, which would wipe
+            // the entire (possibly shared) backend and clobber other tests. Doing
+            // it up front also clears anything an earlier aborted run left behind,
+            // so the Session 1 "first write returns None" assertion is reliable.
+            {
+                let pers = acc_mgr(backend.clone())
+                    .await
+                    .get_persistence_handler()
+                    .clone();
+                let _ = pers.remove_byte_map_values_by_key(0, 0, key).await?;
+            }
 
             // Session 1: write two sub_keys under CID 0.
             let (s1_one, s1_two) = {
@@ -664,9 +678,9 @@ mod tests {
                     .get_persistence_handler()
                     .clone();
                 (
-                    pers.store_byte_map_value(0, 0, "thekey", "sub_one", value.clone())
+                    pers.store_byte_map_value(0, 0, key, "sub_one", value.clone())
                         .await?,
-                    pers.store_byte_map_value(0, 0, "thekey", "sub_two", sibling.clone())
+                    pers.store_byte_map_value(0, 0, key, "sub_two", sibling.clone())
                         .await?,
                 )
             };
@@ -680,10 +694,9 @@ mod tests {
                     .get_persistence_handler()
                     .clone();
                 (
-                    pers.get_byte_map_value(0, 0, "thekey", "sub_one").await?,
-                    pers.get_byte_map_values_by_key(0, 0, "thekey").await?.len(),
-                    pers.remove_byte_map_value(0, 0, "thekey", "sub_one")
-                        .await?,
+                    pers.get_byte_map_value(0, 0, key, "sub_one").await?,
+                    pers.get_byte_map_values_by_key(0, 0, key).await?.len(),
+                    pers.remove_byte_map_value(0, 0, key, "sub_one").await?,
                 )
             };
 
@@ -692,11 +705,13 @@ mod tests {
                 .await
                 .get_persistence_handler()
                 .clone();
-            let s3_one = pers3.get_byte_map_value(0, 0, "thekey", "sub_one").await?;
-            let s3_two = pers3.get_byte_map_value(0, 0, "thekey", "sub_two").await?;
+            let s3_one = pers3.get_byte_map_value(0, 0, key, "sub_one").await?;
+            let s3_two = pers3.get_byte_map_value(0, 0, key, "sub_two").await?;
 
-            // Unconditional cleanup before any assertion can panic.
-            let _ = pers3.purge().await?;
+            // Targeted cleanup of only this test's key, before any assertion can
+            // panic. A later run's up-front cleanup covers the case where an op
+            // above returns Err and skips this line.
+            let _ = pers3.remove_byte_map_values_by_key(0, 0, key).await?;
 
             assert!(
                 s1_one.is_none() && s1_two.is_none(),

--- a/citadel_user/tests/primary.rs
+++ b/citadel_user/tests/primary.rs
@@ -653,67 +653,78 @@ mod tests {
             }
             log::info!(target: "citadel", "Reload test on backend: {backend:?}");
 
-            // Session 1: write two sub_keys under CID 0.
-            {
-                let pers = acc_mgr(backend.clone())
-                    .await
-                    .get_persistence_handler()
-                    .clone();
-                assert!(pers
-                    .store_byte_map_value(0, 0, "thekey", "sub_one", value.clone())
-                    .await?
-                    .is_none());
-                assert!(pers
-                    .store_byte_map_value(0, 0, "thekey", "sub_two", sibling.clone())
-                    .await?
-                    .is_none());
-            }
+            // Capture every read/write first and `purge` before asserting, so a
+            // failed expectation can never skip cleanup and leave CID-0 state on
+            // a shared backend (e.g. SQL/Redis) to contaminate a later run.
 
-            // Session 2: reopen the same backend. Both values must survive the
-            // setup_local_only_account run inside AccountManager::new.
-            {
+            // Session 1: write two sub_keys under CID 0.
+            let (s1_one, s1_two) = {
                 let pers = acc_mgr(backend.clone())
                     .await
                     .get_persistence_handler()
                     .clone();
-                assert_eq!(
+                (
+                    pers.store_byte_map_value(0, 0, "thekey", "sub_one", value.clone())
+                        .await?,
+                    pers.store_byte_map_value(0, 0, "thekey", "sub_two", sibling.clone())
+                        .await?,
+                )
+            };
+
+            // Session 2: reopen the backend (a genuine restart that runs
+            // setup_local_only_account), read the persisted values, then remove
+            // one — that mutation must itself persist into session 3.
+            let (s2_one, s2_key_count, s2_removed) = {
+                let pers = acc_mgr(backend.clone())
+                    .await
+                    .get_persistence_handler()
+                    .clone();
+                (
                     pers.get_byte_map_value(0, 0, "thekey", "sub_one").await?,
-                    Some(value.clone()),
-                    "CID-0 byte_map value was wiped on reload for {backend:?}"
-                );
-                assert_eq!(
                     pers.get_byte_map_values_by_key(0, 0, "thekey").await?.len(),
-                    2,
-                    "CID-0 byte_map sub_keys were wiped on reload for {backend:?}"
-                );
-                // A mutation issued after reload must itself persist.
-                assert_eq!(
                     pers.remove_byte_map_value(0, 0, "thekey", "sub_one")
                         .await?,
-                    Some(value.clone())
-                );
-            }
+                )
+            };
 
             // Session 3: the removal must have persisted and the sibling survived.
-            {
-                let pers = acc_mgr(backend.clone())
-                    .await
-                    .get_persistence_handler()
-                    .clone();
-                assert!(
-                    pers.get_byte_map_value(0, 0, "thekey", "sub_one")
-                        .await?
-                        .is_none(),
-                    "removal of CID-0 byte_map value did not persist for {backend:?}"
-                );
-                assert_eq!(
-                    pers.get_byte_map_value(0, 0, "thekey", "sub_two").await?,
-                    Some(sibling.clone()),
-                    "sibling CID-0 value lost after reload for {backend:?}"
-                );
-                // Clean up the on-disk artifacts for this backend.
-                let _ = pers.purge().await?;
-            }
+            let pers3 = acc_mgr(backend.clone())
+                .await
+                .get_persistence_handler()
+                .clone();
+            let s3_one = pers3.get_byte_map_value(0, 0, "thekey", "sub_one").await?;
+            let s3_two = pers3.get_byte_map_value(0, 0, "thekey", "sub_two").await?;
+
+            // Unconditional cleanup before any assertion can panic.
+            let _ = pers3.purge().await?;
+
+            assert!(
+                s1_one.is_none() && s1_two.is_none(),
+                "CID-0 byte_map was not empty on first write for {backend:?}"
+            );
+            assert_eq!(
+                s2_one,
+                Some(value.clone()),
+                "CID-0 byte_map value was wiped on reload for {backend:?}"
+            );
+            assert_eq!(
+                s2_key_count, 2,
+                "CID-0 byte_map sub_keys were wiped on reload for {backend:?}"
+            );
+            assert_eq!(
+                s2_removed,
+                Some(value.clone()),
+                "remove did not return the stored CID-0 value for {backend:?}"
+            );
+            assert!(
+                s3_one.is_none(),
+                "removal of CID-0 byte_map value did not persist for {backend:?}"
+            );
+            assert_eq!(
+                s3_two,
+                Some(sibling.clone()),
+                "sibling CID-0 value lost after reload for {backend:?}"
+            );
         }
 
         Ok(())

--- a/citadel_user/tests/primary.rs
+++ b/citadel_user/tests/primary.rs
@@ -627,6 +627,98 @@ mod tests {
         .await
     }
 
+    // Regression test for the CID-0 "local-only account" clobber bug.
+    //
+    // `AccountManager::new` -> `setup_local_only_account` runs on every startup,
+    // *after* the backend has loaded persisted accounts. It used to
+    // unconditionally re-create the CID-0 CNAC and `save_cnac` it, overwriting
+    // the just-loaded CID-0 `byte_map` with an empty one — silently wiping any
+    // data stored under CID 0 (the local node's global KV store) on every
+    // restart. `test_byte_map_local` only exercises a single session, so it
+    // could not catch this; this test forces a real reload.
+    //
+    // Each `acc_mgr` call opens the same backend afresh (new in-memory cache +
+    // a load from disk), so session 2 is a genuine restart. InMemory is skipped
+    // because each open is a brand-new store by design.
+    #[tokio::test]
+    async fn test_local_only_account_byte_map_persists_across_reload() -> Result<(), AccountError> {
+        citadel_logging::setup_log();
+
+        let value = Vec::from("local-only-persisted");
+        let sibling = Vec::from("sibling-value");
+
+        for backend in server_backends() {
+            if matches!(backend, BackendType::InMemory) {
+                continue;
+            }
+            log::info!(target: "citadel", "Reload test on backend: {backend:?}");
+
+            // Session 1: write two sub_keys under CID 0.
+            {
+                let pers = acc_mgr(backend.clone())
+                    .await
+                    .get_persistence_handler()
+                    .clone();
+                assert!(pers
+                    .store_byte_map_value(0, 0, "thekey", "sub_one", value.clone())
+                    .await?
+                    .is_none());
+                assert!(pers
+                    .store_byte_map_value(0, 0, "thekey", "sub_two", sibling.clone())
+                    .await?
+                    .is_none());
+            }
+
+            // Session 2: reopen the same backend. Both values must survive the
+            // setup_local_only_account run inside AccountManager::new.
+            {
+                let pers = acc_mgr(backend.clone())
+                    .await
+                    .get_persistence_handler()
+                    .clone();
+                assert_eq!(
+                    pers.get_byte_map_value(0, 0, "thekey", "sub_one").await?,
+                    Some(value.clone()),
+                    "CID-0 byte_map value was wiped on reload for {backend:?}"
+                );
+                assert_eq!(
+                    pers.get_byte_map_values_by_key(0, 0, "thekey").await?.len(),
+                    2,
+                    "CID-0 byte_map sub_keys were wiped on reload for {backend:?}"
+                );
+                // A mutation issued after reload must itself persist.
+                assert_eq!(
+                    pers.remove_byte_map_value(0, 0, "thekey", "sub_one")
+                        .await?,
+                    Some(value.clone())
+                );
+            }
+
+            // Session 3: the removal must have persisted and the sibling survived.
+            {
+                let pers = acc_mgr(backend.clone())
+                    .await
+                    .get_persistence_handler()
+                    .clone();
+                assert!(
+                    pers.get_byte_map_value(0, 0, "thekey", "sub_one")
+                        .await?
+                        .is_none(),
+                    "removal of CID-0 byte_map value did not persist for {backend:?}"
+                );
+                assert_eq!(
+                    pers.get_byte_map_value(0, 0, "thekey", "sub_two").await?,
+                    Some(sibling.clone()),
+                    "sibling CID-0 value lost after reload for {backend:?}"
+                );
+                // Clean up the on-disk artifacts for this backend.
+                let _ = pers.purge().await?;
+            }
+        }
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_byte_map2() -> Result<(), AccountError> {
         test_harness(|container, pers_cl, _pers_se| async move {


### PR DESCRIPTION
## Overview

On a persistent backend (filesystem / SQL / Redis), any data written under CID 0 — the local-only "global" key-value store exposed via `propose_target(0, 0)` + `BackendHandler::{get,set,remove}` (i.e. `byte_map` with `session_cid = 0`) — was silently wiped on every process restart. A node that uses CID 0 to persist account-independent metadata loses all of it on reboot.

## Root cause

`AccountManager::new` calls `setup_local_only_account()` on every startup, *after* the backend's `connect()` has already loaded persisted accounts (including the CID-0 CNAC and its `byte_map`). `setup_local_only_account` then unconditionally built a fresh transient CID-0 CNAC with an empty `byte_map` and called `save_cnac`, overwriting both the in-memory `clients[0]` entry and the on-disk CNAC file. The just-loaded data was clobbered before anything could read it.

This is not a missing-storage problem. CID-0 `byte_map` already round-trips correctly through the standard CNAC persistence path — the data was persisted on write and reloaded on boot, then immediately overwritten by the unconditional re-create.

## Fix

Make `setup_local_only_account` idempotent: if a CID-0 account already exists (i.e. it was loaded from a persistent backend), keep it; only create a fresh CID-0 CNAC when none exists. This preserves the account's `byte_map` across restarts through the existing, designed mechanism, with no parallel storage path.

Behavioral impact is confined to the reload case:
- Fresh backend (first run, and always for in-memory): unchanged — the account is created exactly as before.
- Reloaded persistent backend: the persisted CID-0 account and its data are now retained instead of wiped.

CID 0 is local-only ("Network requests to the zero CID will be rejected by the networking layer"), so its crypto/ratchet state is never used on the wire and reusing the persisted account is safe. It also keeps cid 0's real `cnacs` row, so the SQL `bytemap`→`cnacs` foreign key is satisfied naturally.

## Testing

- New regression test `test_local_only_account_byte_map_persists_across_reload`: writes two sub-keys under CID 0, reopens the same backend (a genuine `AccountManager::new` → load → `setup_local_only_account` cycle), and asserts both values survive; then removes one across a second reload and asserts the removal persists while the sibling remains. It fails on the pre-fix code (`left: None, right: Some(...)`) and passes with the fix.
- `test_byte_map_local` only exercised a single session, so it could not catch this; the new test forces a real reload.
- Full `citadel_user` `primary` suite passes (15/15, run with `SKIP_EXT_BACKENDS=1`); `cargo clippy -p citadel_user --tests` is clean; `cargo fmt --check` is clean.

## Scope

No consumer changes are required. Callers using the CID-0 KV path keep working unchanged and gain durability across restarts.
