### PR TITLE
fix(citadel_io): make publishable (loosen wasm tokio pin to ^1.36)

### DIFF
--- a/citadel_io/Cargo.toml
+++ b/citadel_io/Cargo.toml
@@ -51,7 +51,11 @@ io-uring = { workspace = true, optional = true }
 libc = { workspace = true, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-tokio_wasm = { package = "tokio", version = "=1.36.0", git = "https://github.com/second-state/wasi_tokio.git", branch = "v1.36.x", features = [
+# NOTE: `git` forces the WASI fork (branch v1.36.x = tokio 1.36.0) for actual wasm builds; the
+# version is only a constraint. It must stay caret-compatible with the native tokio requirement
+# (^1.47) so `cargo package`/publish — which strips the git source and maps both to crates.io —
+# can resolve a single tokio version. An exact `=1.36.0` pin makes the crate unpublishable.
+tokio_wasm = { package = "tokio", version = "1.36", git = "https://github.com/second-state/wasi_tokio.git", branch = "v1.36.x", features = [
     "macros",
     "sync",
     "rt",


### PR DESCRIPTION
## Problem

The 0.14.0 crates.io release (run via the new publish pipeline) published `citadel_io_macros` then **failed packaging `citadel_io`**:

```
failed to select a version for `tokio`.
  versions that meet the requirements `=1.36.0` are: 1.36.0
  all possible versions conflict with previously selected packages
  previously selected package `tokio v1.47.1` ... `tokio = "^1.47.0"`
```

`citadel_io`'s wasm target depends on a WASI **tokio fork** pinned at exact `=1.36.0` via `git`. On `cargo package`/publish, the git source is stripped and the dependency is mapped onto crates.io using its version requirement — so wasm `=1.36.0` and native `^1.47.0` both resolve against crates.io `tokio` and **cannot be unified** (exact 1.36.0 vs ≥1.47).

This is new in 0.14: `0.13.0` shipped native tokio `^1.36` with **no** wasm fork dep; the 0.14 cycle bumped native tokio to 1.47 **and** added the git fork.

## Fix

Loosen the wasm requirement `=1.36.0` → `^1.36`. The `git`/`branch` keys still **force the WASI fork** (tokio 1.36.0) for actual wasm builds — the version field is only a constraint — so wasm behavior is unchanged, while publish-time resolution can unify on the native tokio.

## Verification
- `cargo package -p citadel_io --no-verify` now **succeeds** (previously failed).
- `cargo check -p citadel_io` passes; `Cargo.lock` unchanged — the fork still resolves to `tokio 1.36.0` from `git+...wasi_tokio?branch=v1.36.x`, coexisting with native `1.47.1`.
- The wasm CI job (`docker_wasm_p2p`) validates the wasm build end-to-end.

Only `citadel_io` has git-fork deps, so this unblocks the whole publish chain. After merge, the release is re-run (`bump=none`); the pipeline is idempotent and skips the already-published `citadel_io_macros`.

https://claude.ai/code/session_01Xx3XQV7uB6qsRiftXcWvSZ