### PR TITLE
fix(ci): eliminate systemic root causes of CI flakiness

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,14 @@
+# Build-network resilience (SSOT — docker images `COPY . .`, so every build context inherits this).
+# crates.io downloads over HTTP/2 intermittently abort with "[16] Error in the HTTP2 framing layer"
+# (a CDN/proxy hiccup); this repeatedly failed docker NAT image builds during releases. Disabling
+# HTTP/2 multiplexing forces resilient single-stream HTTP, and a high retry count rides out blips.
+[net]
+retry = 10
+git-fetch-with-cli = true
+
+[http]
+multiplexing = false
+
 # Enable ARMv8 hardware AES (FEAT_AES) for the RustCrypto `aes` crate on aarch64. The 0.8.x
 # `aes` crate gates its aarch64 hardware backend behind `--cfg aes_armv8` (x86-64 AES-NI is
 # already runtime-detected and needs nothing here). Measured: AES-GCM per-message protect

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -67,6 +67,9 @@ jobs:
         run: cargo make ratchet-stability-test
   core_libs:
     strategy:
+      # One flaky leg must not cancel its siblings — each leg is an independent OS/NAT-pair
+      # with no cross-leg dependency, and cancelling destroys which leg actually failed.
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
@@ -180,6 +183,9 @@ jobs:
 
   nat:
     strategy:
+      # One flaky leg must not cancel its siblings — each leg is an independent OS/NAT-pair
+      # with no cross-leg dependency, and cancelling destroys which leg actually failed.
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
@@ -222,15 +228,22 @@ jobs:
         uses: Avarok-Cybersecurity/gh-actions-deps@master
       - uses: taiki-e/install-action@nextest
       - run: cargo nextest run --package netbeam
+      # --release: the UDP-traversal timing tests (esp. the high-lag consensus regression) are
+      # calibrated against fixed timeouts; a debug build's slowness widens the lag/barrier
+      # windows enough that shared-runner scheduler jitter tips a boundary-calibrated attempt
+      # over its deadline. Release removes that confounder (mirrors the citadel_sdk_release job).
       - name: Run basic localhost NAT tests
         if: ${{ !startsWith(matrix.os, 'windows') }}
-        run: cargo nextest run --package citadel_wire --features=localhost-testing
+        run: cargo nextest run --release --package citadel_wire --features=localhost-testing
       - name: Run basic localhost NAT tests (windows only)
         if: startsWith(matrix.os, 'windows')
-        run: cargo nextest run --package citadel_wire --features=localhost-testing,vendored
+        run: cargo nextest run --release --package citadel_wire --features=localhost-testing,vendored
 
   citadel_sdk:
     strategy:
+      # One flaky leg must not cancel its siblings — each leg is an independent OS/NAT-pair
+      # with no cross-leg dependency, and cancelling destroys which leg actually failed.
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
@@ -534,6 +547,9 @@ jobs:
   docker_nat_client_server:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky leg must not cancel its siblings — each leg is an independent OS/NAT-pair
+      # with no cross-leg dependency, and cancelling destroys which leg actually failed.
+      fail-fast: false
       matrix:
         nat_type_client_a:
           - "full_cone"
@@ -551,6 +567,9 @@ jobs:
   docker_nat_p2p:
     runs-on: ubuntu-latest
     strategy:
+      # One flaky leg must not cancel its siblings — each leg is an independent OS/NAT-pair
+      # with no cross-leg dependency, and cancelling destroys which leg actually failed.
+      fail-fast: false
       matrix:
         nat_type_peer_a:
           - "full_cone"

--- a/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
+++ b/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
@@ -436,10 +436,15 @@ mod tests {
         citadel_logging::setup_log();
         const LAG_MS: usize = 450;
         const ITERS: usize = 5;
-        // Big enough to absorb a 20s attempt-timeout followed by a recovering retry (the retry now
-        // re-pairs instead of deadlocking). A genuine failure (consensus never agreeing) still trips
-        // it within MAX_RETRIES × DEFAULT_TIMEOUT.
-        const PER_ITER_TIMEOUT: Duration = Duration::from_secs(75);
+        // Derive the per-iter budget from the production retry envelope (SSOT) rather than a magic
+        // literal that silently drifts if DEFAULT_TIMEOUT/MAX_RETRIES change: a full run is at most
+        // MAX_RETRIES attempt-timeouts, plus slack for the post-consensus datagram round-trip. This
+        // is exactly the production worst case — NOT inflated — so a genuine consensus deadlock still
+        // trips it. (The actual flake fix is running this job in --release; see validate.yml.)
+        const DATAGRAM_EXCHANGE_SLACK: Duration = Duration::from_secs(15);
+        let per_iter_timeout = super::DEFAULT_TIMEOUT
+            .saturating_mul(super::MAX_RETRIES as u32)
+            .saturating_add(DATAGRAM_EXCHANGE_SLACK);
 
         for i in 0..ITERS {
             let (server_stream, client_stream) = create_streams_with_addrs_and_lag(LAG_MS).await;
@@ -481,7 +486,7 @@ mod tests {
                 assert_ne!(len, 0);
             };
 
-            match citadel_io::tokio::time::timeout(PER_ITER_TIMEOUT, iteration).await {
+            match citadel_io::tokio::time::timeout(per_iter_timeout, iteration).await {
                 Ok(()) => {
                     log::info!(target: "citadel", "[hole-punch-consensus] iter {i}/{ITERS} OK")
                 }

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -4,5 +4,8 @@ COPY . .
 COPY ./docker/set_nat.sh .
 COPY ./docker/client/exec.sh .
 RUN apt-get update --fix-missing && apt-get install --fix-missing -y openssl libclang-dev build-essential cmake iptables inetutils-ping net-tools iproute2 && rm -rf /var/lib/apt/lists/*
+# crates.io fetch resilience (mirrors .cargo/config.toml; guards the transient
+# "[16] Error in the HTTP2 framing layer" that aborts NAT image builds).
+ENV CARGO_NET_RETRY=10 CARGO_HTTP_MULTIPLEXING=false CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN cargo install --example client --path ./citadel_sdk --debug
 RUN ["chmod", "u+x", "exec.sh"]

--- a/docker/peer/Dockerfile
+++ b/docker/peer/Dockerfile
@@ -4,5 +4,8 @@ COPY . .
 COPY ./docker/set_nat.sh .
 COPY ./docker/peer/exec.sh .
 RUN apt-get update --fix-missing && apt-get install --fix-missing -y openssl libclang-dev build-essential cmake iptables inetutils-ping net-tools iproute2 && rm -rf /var/lib/apt/lists/*
+# crates.io fetch resilience (mirrors .cargo/config.toml; guards the transient
+# "[16] Error in the HTTP2 framing layer" that aborts NAT image builds).
+ENV CARGO_NET_RETRY=10 CARGO_HTTP_MULTIPLEXING=false CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN cargo install --example peer --path ./citadel_sdk --debug
 RUN ["chmod", "u+x", "exec.sh"]

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,5 +4,8 @@ COPY . .
 COPY ./docker/set_nat.sh .
 COPY ./docker/server/exec.sh .
 RUN apt-get update --fix-missing && apt-get install --fix-missing -y openssl libclang-dev build-essential cmake iptables inetutils-ping net-tools iproute2 && rm -rf /var/lib/apt/lists/*
+# crates.io fetch resilience (mirrors .cargo/config.toml; guards the transient
+# "[16] Error in the HTTP2 framing layer" that aborts NAT image builds).
+ENV CARGO_NET_RETRY=10 CARGO_HTTP_MULTIPLEXING=false CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN cargo install --example server --path ./citadel_sdk --debug
 RUN ["chmod", "u+x", "exec.sh"]

--- a/docker/wasm_p2p/Dockerfile.server
+++ b/docker/wasm_p2p/Dockerfile.server
@@ -2,6 +2,9 @@ FROM rust:latest as builder
 WORKDIR /usr/src/app
 COPY . .
 RUN apt-get update --fix-missing && apt-get install --fix-missing -y openssl libclang-dev build-essential cmake && rm -rf /var/lib/apt/lists/*
+# crates.io fetch resilience (mirrors .cargo/config.toml; guards the transient
+# "[16] Error in the HTTP2 framing layer" that aborts image builds).
+ENV CARGO_NET_RETRY=10 CARGO_HTTP_MULTIPLEXING=false CARGO_NET_GIT_FETCH_WITH_CLI=true
 RUN cargo install --example wasm_test_server --path ./citadel_sdk --features localhost-testing --debug
 COPY ./docker/wasm_p2p/exec_server.sh .
 RUN ["chmod", "u+x", "exec_server.sh"]


### PR DESCRIPTION
## Background

A multi-agent root-cause investigation (4 parallel investigators → adversarial verification of every finding → synthesized plan) traced this session's CI flakes to a small set of **systemic** causes. This PR fixes the high-confidence ones and **deliberately does not paper over** the one genuine-but-unconfirmed product race.

## Root causes fixed

**1. No build-network resilience** — the most frequent flake we actually hit.
crates.io downloads over HTTP/2 intermittently abort with `[16] Error in the HTTP2 framing layer`, which repeatedly failed docker NAT image builds during the release. Fix: `[net] retry=10` + `[http] multiplexing=false` in `.cargo/config.toml` (SSOT — docker images `COPY . .` so they inherit it), mirrored as `CARGO_NET_RETRY` / `CARGO_HTTP_MULTIPLEXING` env in each Dockerfile that runs `cargo install`. Disabling HTTP/2 multiplexing is the load-bearing remedy (forces resilient single-stream HTTP); retry rides out CDN blips.

**2. Matrix fail-fast amplification.** All 5 build/test matrices defaulted to `fail-fast: true`, so a single flaky leg cancelled all siblings and erased which leg actually failed (we saw 15 `docker_nat_p2p` legs cancelled by one transient download error). Set `fail-fast: false` on all matrices — strictly more signal, zero masking (each leg still reports its own pass/fail).

**3. Hole-punch high-lag consensus timing flake.** `test_dual_hole_puncher_high_lag_consensus` is calibrated against the production 20s per-attempt timeout; a **debug** build's slowness widens the simulated-lag/barrier windows enough that shared macOS-runner scheduler jitter tips an attempt over its deadline. Fixes:
- Run the `citadel_wire` NAT tests in `--release` (removes the debug-slowness confounder; mirrors the existing `citadel_sdk_release` job). This is the actual flake fix.
- Derive the test's per-iter budget from `DEFAULT_TIMEOUT * MAX_RETRIES + slack` (SSOT) instead of a magic `75s` literal — same value, but self-correcting and not inflated. The end-to-end datagram round-trip assertion is **kept**, so a genuine consensus desync still fails fast.

## Deliberately NOT included (honest report)

The `citadel_sdk` `stress_reconnect_p2p` flake (`RemoteP2pConnectTimeout` after 60s). The investigation proposed a server-side reconnect-teardown race, but **independent verification refuted its specific mechanism**: `insert_new_virtual_connection_as_server` *overwrites* the stale inactive vconn on reconnect (it doesn't collide), and the proto layer sends `PeerChannelCreated` **unconditionally** within a 30s inner cap. A 60s miss therefore means the *pre-punch reconnect signaling* wedged — a real but unpinned mechanism. Fixing it requires a reproduction before touching cryptographic session teardown, and I explicitly did **not** inflate the 60s SDK timeout (which would mask the wedge). Tracking as a focused follow-up.

## Verification
- Workspace builds; `.cargo/config.toml` + `validate.yml` parse.
- `test_dual_hole_puncher_high_lag_consensus` passes in `--release` locally (50s, within the derived budget).
- nextest `retries=0` intentionally left as-is (auto-retry would mask the reconnect-deadlock class).

https://claude.ai/code/session_01Xx3XQV7uB6qsRiftXcWvSZ