### PR TITLE
fix(async_ip): trim IP-echo response before parsing (robustness)

### DIFF
--- a/async_ip/src/lib.rs
+++ b/async_ip/src/lib.rs
@@ -180,7 +180,18 @@ pub async fn get_ip_from(
         .await
         .map_err(|err| IpRetrieveError::ip_retrieve(err.to_string()))?;
 
-    IpAddr::from_str(text.as_str()).map_err(|err| IpRetrieveError::ip_retrieve(err.to_string()))
+    parse_ip_response(&text)
+}
+
+/// Parses an IP address out of an IP-echo service's HTTP response body.
+///
+/// Several of the upstream services append a trailing newline (and some surround the
+/// address with whitespace), which `IpAddr::from_str` rejects verbatim. Trimming first
+/// makes resolution robust to those harmless formatting differences instead of letting an
+/// otherwise-valid fallback service fail. The trimmed text must still be exactly one IP
+/// address — embedded whitespace or extra tokens are still rejected.
+fn parse_ip_response(text: &str) -> Result<IpAddr, IpRetrieveError> {
+    IpAddr::from_str(text.trim()).map_err(|err| IpRetrieveError::ip_retrieve(err.to_string()))
 }
 
 // --- Platform-specific internal IP resolution ---
@@ -245,3 +256,47 @@ pub fn get_default_client() -> reqwest::Client {
 
 /// The default error type for this crate
 pub type IpRetrieveError = citadel_io::NetworkError;
+
+#[cfg(test)]
+mod tests {
+    use super::parse_ip_response;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn parses_bare_ipv4() {
+        assert_eq!(
+            parse_ip_response("1.2.3.4").unwrap(),
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))
+        );
+    }
+
+    #[test]
+    fn trims_trailing_newline() {
+        // Some IP-echo services append a trailing '\n'; this previously broke parsing.
+        assert_eq!(
+            parse_ip_response("1.2.3.4\n").unwrap(),
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))
+        );
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace_and_crlf() {
+        assert_eq!(
+            parse_ip_response("  1.2.3.4  ").unwrap(),
+            IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))
+        );
+        assert_eq!(
+            parse_ip_response("2001:db8::1\r\n").unwrap(),
+            IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))
+        );
+    }
+
+    #[test]
+    fn rejects_garbage_and_embedded_tokens() {
+        assert!(parse_ip_response("").is_err());
+        assert!(parse_ip_response("not-an-ip").is_err());
+        // Trimming must not turn a multi-token body into a valid parse.
+        assert!(parse_ip_response("1.2.3.4 5.6.7.8").is_err());
+        assert!(parse_ip_response("<html>error</html>").is_err());
+    }
+}


### PR DESCRIPTION
## What

`async_ip::get_ip_from` parsed the raw HTTP response body of an IP-echo service directly with `IpAddr::from_str(text)`. `from_str` is strict and rejects any surrounding whitespace, so a body like `"1.2.3.4\n"` (or `"2001:db8::1\r\n"`) fails to parse even though it carries a perfectly valid address.

This PR extracts a small pure helper, `parse_ip_response`, that trims surrounding whitespace before parsing, and adds unit tests.

```rust
fn parse_ip_response(text: &str) -> Result<IpAddr, IpRetrieveError> {
    IpAddr::from_str(text.trim()).map_err(|err| IpRetrieveError::ip_retrieve(err.to_string()))
}
```

## Why

Several of the upstream services this crate queries (`ipify`, `ident.me`, `ipv6-test.com`) commonly terminate their plaintext response with a newline. With the strict parse, such a response is silently treated as a failure, needlessly discarding a healthy fallback and reducing the reliability that the multi-service concurrent resolution is designed to provide. Trimming is the conventional, harmless fix for IP-echo response handling.

Verified empirically that `IpAddr::from_str("1.2.3.4\n")` returns `Err`, while `IpAddr::from_str("1.2.3.4\n".trim())` succeeds.

## Risk

Low. This is a pure parsing-robustness change confined to the `async_ip` crate:
- No protocol, packet, wire-format, crypto, key-exchange, or session-state behavior is touched.
- Trimming only removes leading/trailing ASCII whitespace; the trimmed text must still be exactly one IP address. A test asserts that a multi-token body (`"1.2.3.4 5.6.7.8"`), empty input, and HTML error pages are all still rejected, so trimming cannot loosen validation into accepting embedded garbage.

## How verified

Locally on this branch:
- `cargo build -p async_ip` — clean
- `cargo test -p async_ip` — 4 new unit tests + existing integration/doc tests pass
- `cargo clippy -p async_ip --tests -- -D warnings` — clean
- `cargo fmt -p async_ip -- --check` — clean

New tests cover: bare IPv4, trailing `\n`, surrounding whitespace, IPv6 with CRLF, and rejection of empty/garbage/multi-token bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL5kSutbMiyBoHxUK7ADKS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SL5kSutbMiyBoHxUK7ADKS)_