### PR TITLE
[needs-review] harden(crypt): bounds-check plaintext-slab window in group wave reassembly

### DIFF
--- a/citadel_crypt/src/scramble/crypt_splitter.rs
+++ b/citadel_crypt/src/scramble/crypt_splitter.rs
@@ -883,12 +883,25 @@ impl GroupReceiver {
                     Ok(()) => {
                         let plaintext = &completed_wave.ciphertext_buffer[..];
 
+                        // `max_plaintext_wave_length` is a peer-supplied field that `validate()`
+                        // does NOT bound, so a malicious/buggy config can place this wave's window
+                        // past the pre-sized plaintext slab. Compute the window with checked
+                        // arithmetic and reject an out-of-range result as a corrupt wave instead of
+                        // panicking on the slab slice (DoS hardening — mirrors the `check_bounds`
+                        // guard already applied to the ciphertext-buffer write above).
                         let plaintext_insert_index =
-                            Self::get_plaintext_buffer_insertion_range_by_wave_id(
+                            match Self::get_plaintext_buffer_insertion_range_by_wave_id(
                                 wave_id,
-                                plaintext,
+                                plaintext.len(),
                                 self.max_plaintext_wave_length,
-                            );
+                                self.unified_plaintext_slab.len(),
+                            ) {
+                                Some(range) => range,
+                                None => {
+                                    log::error!(target: "citadel", "Plaintext slab insertion window for wave {wave_id} (len {}, stride {}) is out of bounds for slab of len {}", plaintext.len(), self.max_plaintext_wave_length, self.unified_plaintext_slab.len());
+                                    return GroupReceiverStatus::CORRUPT_WAVE;
+                                }
+                            };
                         let dest_bytes =
                             &mut self.unified_plaintext_slab[plaintext_insert_index.clone()];
                         debug_assert_eq!(
@@ -1013,15 +1026,23 @@ impl GroupReceiver {
         }
     }
 
+    /// Computes the destination window in the unified plaintext slab for a decrypted wave.
+    ///
+    /// Returns `None` (rather than risking an overflow/out-of-bounds slab slice) when the
+    /// peer-supplied `max_plaintext_wave_length` would place the window past `slab_len`. All
+    /// arithmetic is checked so a hostile config cannot wrap into a small, in-bounds-looking range.
     fn get_plaintext_buffer_insertion_range_by_wave_id(
         wave_id: u32,
-        plaintext: &[u8],
+        plaintext_length: usize,
         max_plaintext_wave_length: usize,
-    ) -> Range<usize> {
-        let plaintext_length = plaintext.len();
-        let start_idx = wave_id as usize * max_plaintext_wave_length;
-        let end_idx = start_idx + plaintext_length;
-        start_idx..end_idx
+        slab_len: usize,
+    ) -> Option<Range<usize>> {
+        let start_idx = (wave_id as usize).checked_mul(max_plaintext_wave_length)?;
+        let end_idx = start_idx.checked_add(plaintext_length)?;
+        if end_idx > slab_len {
+            return None;
+        }
+        Some(start_idx..end_idx)
     }
 
     /// Returns the number of waves expected to receive
@@ -1338,5 +1359,50 @@ mod group_config_validation_tests {
         cfg.max_payload_size = 1;
         cfg.last_payload_size = 1;
         assert!(cfg.validate().is_err());
+    }
+
+    // --- plaintext-slab window bounds (DoS hardening for the wave-completion path) ---
+    use super::GroupReceiver;
+
+    #[test]
+    fn plaintext_window_in_bounds_is_accepted() {
+        // wave 1 of stride 360, writing 360 bytes into a 1000-byte slab → [360, 720): in bounds.
+        let range =
+            GroupReceiver::get_plaintext_buffer_insertion_range_by_wave_id(1, 360, 360, 1000);
+        assert_eq!(range, Some(360..720));
+    }
+
+    #[test]
+    fn plaintext_window_past_slab_is_rejected() {
+        // A hostile `max_plaintext_wave_length` pushes the window past the pre-sized slab.
+        // Previously this panicked on the slab slice; it must now be rejected (None).
+        assert_eq!(
+            GroupReceiver::get_plaintext_buffer_insertion_range_by_wave_id(
+                1,
+                10,
+                u32::MAX as usize,
+                1000
+            ),
+            None
+        );
+        // start in-bounds but end past the slab is also rejected.
+        assert_eq!(
+            GroupReceiver::get_plaintext_buffer_insertion_range_by_wave_id(0, 2000, 360, 1000),
+            None
+        );
+    }
+
+    #[test]
+    fn plaintext_window_overflow_is_rejected() {
+        // wave_id * stride must not wrap into a small, in-bounds-looking start index.
+        assert_eq!(
+            GroupReceiver::get_plaintext_buffer_insertion_range_by_wave_id(
+                u32::MAX,
+                0,
+                usize::MAX,
+                usize::MAX
+            ),
+            None
+        );
     }
 }


### PR DESCRIPTION
## What

`GroupReceiver::on_packet_received` (the inbound file-transfer / group reassembly path) writes each fully-received, decrypted wave into `unified_plaintext_slab` using a destination range computed by `get_plaintext_buffer_insertion_range_by_wave_id`. That range is derived from the peer-supplied `max_plaintext_wave_length` field and was sliced into the slab **with no bounds check** — in contrast to the ciphertext-buffer write directly above it, which is already guarded by `check_bounds`.

This PR:
- Reworks `get_plaintext_buffer_insertion_range_by_wave_id` to compute the window with **checked arithmetic** and validate it against the slab length, returning `Option<Range<usize>>`.
- Updates the caller to reject an out-of-range window as `GroupReceiverStatus::CORRUPT_WAVE` (with a log line) instead of indexing the slab.
- Adds unit tests for the in-bounds, past-slab, and integer-overflow cases.

## Why

`GroupReceiverConfig::validate()` (added previously) bounds the allocation-driving fields (`plaintext_length`, `wave_count`, `packets_needed`, `max_payload_size`, `max_packets_per_wave`) to stop a memory-exhaustion DoS, but it does **not** bound `max_plaintext_wave_length`. A `GroupHeader` is AEAD-authenticated, so the sender is an authenticated peer — but a malicious or buggy peer can still supply a config whose per-wave stride places a later wave's window past the pre-sized slab. The previous code would then panic on the slab slice (`index out of bounds`), a fatal-panic DoS on the receiver. The runtime coverage check that catches under/over-coverage only runs *after* the slab write, so it could not prevent the panic.

## Risk

Low and correct-by-construction: the new guard only rejects windows that would have been out of bounds (i.e. would have panicked). Any window that currently succeeds was already `start <= end <= slab.len()`, so it still passes and behaves identically — no legitimate transfer is affected, and no protocol/crypto/wire behavior changes. This is purely a panic→graceful-rejection hardening.

Marked `[needs-review]` because it sits on the packet/session reassembly path; per repo policy I am leaving it open for a human rather than auto-merging.

## How verified

- `cargo build -p citadel_crypt`
- `cargo test -p citadel_crypt --lib` — 66 passed (incl. the 3 new `plaintext_window_*` tests and the existing `group_config_validation_tests`)
- `cargo clippy -p citadel_crypt --tests -- -D warnings` — clean
- `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgkRFZY8wbYgnYQq1yvJwg)_