### PR TITLE
[needs-review] harden(netbeam): stop TimeTracker panicking on a pre-epoch clock

### DIFF
--- a/netbeam/src/time_tracker.rs
+++ b/netbeam/src/time_tracker.rs
@@ -27,6 +27,7 @@
 //! ```
 
 use std::fmt::Formatter;
+use std::time::Duration;
 
 /// A utility for tracking time with nanosecond precision.
 ///
@@ -59,8 +60,31 @@ impl TimeTracker {
     ///
     /// Returns the current time in nanoseconds as an i64.
     /// The returned value will wrap around after approximately 100 years.
+    ///
+    /// This never panics: in the pathological case where the system clock is set *before* the Unix
+    /// epoch (so `elapsed()` reports a backwards duration), we return that duration negated rather
+    /// than unwrapping. The result stays a valid, strictly-ordered `i64`, so the distributed-lock
+    /// tie-break still picks exactly one winner — only fairness is affected, never mutual exclusion.
     pub fn get_global_time_ns(&self) -> i64 {
-        (citadel_io::time::UNIX_EPOCH.elapsed().unwrap().as_nanos() % i64::MAX as u128) as i64
+        // `map_err(|e| e.duration())` normalizes the native and wasm `SystemTimeError` types to a
+        // plain backwards `Duration`, keeping `ns_since_epoch` free of platform-specific types.
+        ns_since_epoch(
+            citadel_io::time::UNIX_EPOCH
+                .elapsed()
+                .map_err(|e| e.duration()),
+        )
+    }
+}
+
+/// Convert the result of `UNIX_EPOCH.elapsed()` into a nanosecond timestamp without panicking.
+///
+/// `Ok(dur)` is time after the epoch (the normal case) and yields a positive value; `Err(back)`
+/// carries how far the clock is *before* the epoch and yields the negated value. Both branches take
+/// the nanosecond count modulo `i64::MAX` so the cast can never overflow.
+fn ns_since_epoch(elapsed: Result<Duration, Duration>) -> i64 {
+    match elapsed {
+        Ok(dur) => (dur.as_nanos() % i64::MAX as u128) as i64,
+        Err(back) => -((back.as_nanos() % i64::MAX as u128) as i64),
     }
 }
 
@@ -75,5 +99,42 @@ impl std::fmt::Debug for TimeTracker {
             "Time tracker current global time: {}ns",
             self.get_global_time_ns()
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ns_since_epoch, TimeTracker};
+    use std::time::Duration;
+
+    #[test]
+    fn forward_clock_is_positive() {
+        assert_eq!(ns_since_epoch(Ok(Duration::from_nanos(0))), 0);
+        assert_eq!(ns_since_epoch(Ok(Duration::from_nanos(1_500))), 1_500);
+    }
+
+    #[test]
+    fn pre_epoch_clock_is_negative_not_a_panic() {
+        // `elapsed()` returns Err carrying the backwards duration when the clock is before the
+        // epoch; previously this path unwrapped and panicked.
+        assert_eq!(ns_since_epoch(Err(Duration::from_nanos(0))), 0);
+        assert_eq!(ns_since_epoch(Err(Duration::from_nanos(2_000))), -2_000);
+    }
+
+    #[test]
+    fn huge_durations_wrap_without_overflowing_the_cast() {
+        // Far beyond i64::MAX nanoseconds (~292 years): must stay in range, never panic on cast.
+        let huge = Duration::from_secs(u64::MAX);
+        let forward = ns_since_epoch(Ok(huge));
+        let backward = ns_since_epoch(Err(huge));
+        assert!(forward >= 0);
+        assert!(backward <= 0);
+        assert_eq!(forward, -backward);
+    }
+
+    #[test]
+    fn real_clock_is_after_epoch() {
+        // Sanity check against the actual system clock used in CI.
+        assert!(TimeTracker::new().get_global_time_ns() > 0);
     }
 }


### PR DESCRIPTION
## What

`TimeTracker::get_global_time_ns()` did `UNIX_EPOCH.elapsed().unwrap()`. `SystemTime::elapsed()` returns `Err` whenever the system clock is set *before* the Unix epoch, so that `unwrap()` panics. This function is called on essentially **every packet craft and process** across `citadel_proto` (sessions, preconnect/connect/register/keepalive/group/file packet processors, etc.), so a single clock anomaly would crash the session.

This PR replaces the `unwrap()` with a non-panicking conversion and extracts a small pure helper:

```rust
fn ns_since_epoch(elapsed: Result<Duration, Duration>) -> i64 {
    match elapsed {
        Ok(dur)  =>  (dur.as_nanos()  % i64::MAX as u128) as i64,
        Err(back) => -((back.as_nanos() % i64::MAX as u128) as i64),
    }
}
```

`get_global_time_ns()` normalizes the native and wasm `SystemTimeError` types via `.map_err(|e| e.duration())` so the helper stays platform-agnostic.

## Why

- **Removes a panic from a ubiquitous non-test production path** triggered by environment clock state (misconfigured embedded/CI clocks, NTP stepping).
- **Behavior-preserving in the normal case:** for any clock at/after the epoch the returned value is identical to before (positive ns mod `i64::MAX`).

## Risk

Low. This does **not** touch crypto, key-exchange, ratchet, handshake, or protocol/packet semantics — only how a timestamp utility handles a clock that predates the epoch.

The function's existing doc already states the timestamp's value only affects *fairness* in the `net_mutex`/`net_rwlock` distributed-lock tie-break, never mutual exclusion (both peers compare the absolute transmitted values with a strict, deterministically tie-broken ordering). A negative `i64` remains a valid, strictly-ordered value, so that invariant is preserved. The only changed behavior is in the previously-panicking pre-epoch edge case.

## How verified

- `cargo build -p netbeam` ✅
- `cargo test -p netbeam --lib time_tracker` ✅ — added 4 unit tests covering the forward, pre-epoch (the old panic), and overflow-wrap branches plus a real-clock sanity check.
- `cargo clippy -p netbeam --tests -- -D warnings` ✅
- `cargo fmt` ✅
- Confirmed `wasmtimer 0.4.3`'s `SystemTimeError::duration()` exists so the wasm `citadel_io::time` re-export path also compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mSKT5yUcD61QkUsiZfy3T

---
_Generated by [Claude Code](https://claude.ai/code/session_011mSKT5yUcD61QkUsiZfy3T)_