### PR TITLE
[needs-review] harden(user): cap untrusted bincode deserialization at input length (anti-DoS)

### DIFF
--- a/citadel_user/src/serialization.rs
+++ b/citadel_user/src/serialization.rs
@@ -82,10 +82,35 @@
 
 use crate::misc::AccountError;
 use bincode::BincodeRead;
+use bincode::Options;
 use bytes::BufMut;
 use bytes::BytesMut;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+
+/// Builds the bincode configuration used for deserializing untrusted input.
+///
+/// This is byte-for-byte identical to the configuration used by the free
+/// `bincode::deserialize` / `bincode::deserialize_from` functions
+/// (fixint encoding, little-endian, trailing bytes allowed) with one addition:
+/// a byte limit equal to the length of the input buffer.
+///
+/// A correctly-encoded value can never require reading more bytes than the
+/// input itself contains, so the limit never rejects a legitimate message.
+/// What it does prevent is a hostile peer sending a tiny packet whose internal
+/// length prefix (e.g. for a `Vec<u8>` or `String` field) claims billions of
+/// elements: without a limit, bincode honors that prefix and attempts the
+/// corresponding heap allocation *before* discovering the bytes are not there,
+/// turning a few-byte packet into a multi-gigabyte allocation (remote
+/// memory-exhaustion DoS). With the limit, the oversized length is rejected up
+/// front with a clean `SizeLimit` error and no allocation occurs.
+#[inline]
+fn limited_options(input_len: usize) -> impl Options {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .allow_trailing_bytes()
+        .with_limit(input_len as u64)
+}
 
 /// Convenient serialization methods for types that #[derive(Serialize, Deserialize)]
 pub trait SyncIO {
@@ -110,12 +135,17 @@ pub trait SyncIO {
         Self: DeserializeOwned,
     {
         use bytes::Buf;
-        bincode::deserialize_from(input.reader()).map_err(|err| {
-            citadel_io::error!(
-                citadel_io::ErrorCode::DeserializationFailed,
-                err.to_string()
-            )
-        })
+        // Cap the allocation at the input length to defeat length-prefix
+        // allocation bombs from untrusted peers (see `limited_options`).
+        // Wire-compatible with the previous `bincode::deserialize_from` call.
+        limited_options(input.len())
+            .deserialize_from(input.reader())
+            .map_err(|err| {
+                citadel_io::error!(
+                    citadel_io::ErrorCode::DeserializationFailed,
+                    err.to_string()
+                )
+            })
     }
 
     /// Deserializes in-place
@@ -170,12 +200,17 @@ impl<'a, T> SyncIO for T where T: Serialize + Deserialize<'a> + Sized {}
 
 /// Deserializes the bytes, T, into type D
 fn bytes_to_type<'a, D: Deserialize<'a>>(bytes: &'a [u8]) -> Result<D, AccountError> {
-    bincode::deserialize(bytes).map_err(|err| {
-        citadel_io::error!(
-            citadel_io::ErrorCode::DeserializationFailed,
-            err.to_string()
-        )
-    })
+    // Cap the allocation at the input length to defeat length-prefix allocation
+    // bombs from untrusted peers (see `limited_options`). Wire-compatible with
+    // the previous `bincode::deserialize` call.
+    limited_options(bytes.len())
+        .deserialize(bytes)
+        .map_err(|err| {
+            citadel_io::error!(
+                citadel_io::ErrorCode::DeserializationFailed,
+                err.to_string()
+            )
+        })
 }
 
 /// Converts a type, D to Vec<u8>
@@ -237,5 +272,42 @@ mod tests {
     fn deserialize_garbage_errors() {
         assert!(Sample::deserialize_from_vector(&[0xFFu8; 2]).is_err());
         assert!(Sample::deserialize_from_owned_vector(vec![0xFFu8; 2]).is_err());
+    }
+
+    /// A hostile peer can hand-craft a tiny payload whose internal length prefix
+    /// claims a huge number of elements. Before the byte-limit hardening, bincode
+    /// would honor the prefix and attempt the corresponding (multi-gigabyte) heap
+    /// allocation before noticing the bytes are absent — a remote
+    /// memory-exhaustion DoS. The deserializer must now reject these cheaply.
+    #[test]
+    fn rejects_oversized_length_prefix() {
+        // `Vec<u8>` is length-prefixed by a fixint u64 (8 little-endian bytes).
+        // Claim ~18 EB of elements but supply no payload.
+        let mut malicious = u64::MAX.to_le_bytes().to_vec(); // length prefix = u64::MAX
+        malicious.extend_from_slice(&[0u8; 4]); // a few real bytes, far fewer than claimed
+
+        // Must error (not allocate/OOM). The wrapper caps the limit at the input
+        // length, so the oversized prefix is rejected up front.
+        assert!(Vec::<u8>::deserialize_from_vector(&malicious).is_err());
+        assert!(Vec::<u8>::deserialize_from_owned_vector(malicious.clone()).is_err());
+
+        // The same protection applies to `String` fields.
+        assert!(String::deserialize_from_vector(&malicious).is_err());
+    }
+
+    /// The byte limit must never reject a legitimately-encoded value: a valid
+    /// encoding can never need to read more bytes than the buffer it came from.
+    #[test]
+    fn limit_preserves_valid_roundtrip_for_large_payloads() {
+        // A genuinely large (but self-consistent) payload round-trips fine,
+        // because the limit equals the encoded length.
+        let big = Sample {
+            id: 9,
+            name: "n".repeat(100_000),
+            flags: vec![true; 50_000],
+        };
+        let bytes = big.serialize_to_vector().unwrap();
+        assert_eq!(Sample::deserialize_from_vector(&bytes).unwrap(), big);
+        assert_eq!(Sample::deserialize_from_owned_vector(bytes).unwrap(), big);
     }
 }


### PR DESCRIPTION
## What

Adds a byte limit to the two central bincode deserialization helpers in `citadel_user::serialization` — `bytes_to_type` and `deserialize_from_owned_vector` — equal to the length of the input buffer. These helpers back every `SyncIO::deserialize_*` call across the workspace.

## Why (threat model)

`SyncIO::deserialize_*` is the deserialization entry point for **attacker-controlled** protocol payloads: peer signals, group/CGKA artifacts (`KeyPackage`/`Welcome`/`Commit`/`AppCiphertext`), file-transfer metadata, and register/connect packets (see `citadel_proto/src/proto/validation.rs`, `.../peer/group_cgka/mod.rs`, `.../peer/peer_cmd_packet.rs`, etc.).

Previously these used the unbounded `bincode::deserialize` / `bincode::deserialize_from`. bincode honors a collection's length prefix **before** reading the elements:

```rust
fn read_vec(&mut self) -> Result<Vec<u8>> {
    let len = O::IntEncoding::deserialize_len(self)?;
    self.read_bytes(len as u64)?;        // limit checked here
    self.reader.get_byte_buffer(len)     // allocates `len` bytes here
}
```

With no byte limit, a hostile peer can send a few-byte packet whose internal length prefix for a `Vec<u8>`/`String` field claims up to `u64::MAX` elements. bincode then attempts the corresponding multi-gigabyte allocation before noticing the bytes aren't present — a cheap **remote memory-exhaustion DoS** (OOM / abort).

## Fix

Deserialize through a bincode config that is byte-for-byte identical to the free functions (`fixint`, little-endian, trailing bytes allowed) plus a byte limit equal to the input length:

```rust
bincode::DefaultOptions::new()
    .with_fixint_encoding()
    .allow_trailing_bytes()
    .with_limit(input_len as u64)
```

A correctly-encoded value can never need to read more bytes than the buffer it came from, so the limit **never rejects a legitimate message**. An oversized length prefix is now rejected up front with a clean `SizeLimit` error and **no allocation** occurs (the limit is enforced in `read_bytes`, before `get_byte_buffer`).

## Risk

- **Wire format: unchanged.** The config matches `bincode::deserialize`/`deserialize_from` exactly (verified against bincode 1.3.3 source); only an allocation cap is added.
- **Successful-path behavior: unchanged.** The limit equals the input length, which can only ever bound the *failure* path. Validated by a new test that round-trips a large (150k-element) self-consistent payload.
- `deserialize_in_place` is intentionally left as-is (no callers in the workspace).
- Local persistence paths (disk/SQL/redis backends) also flow through these helpers; the limit there equals the stored blob length, so valid records still load.

## How verified

- `cargo build -p citadel_user` / `-p citadel_proto` — OK
- `cargo test -p citadel_user --lib serialization` — 6/6 pass, including:
  - `rejects_oversized_length_prefix` — `u64::MAX` length prefix with no payload is rejected (no OOM) for `Vec<u8>` and `String`.
  - `limit_preserves_valid_roundtrip_for_large_payloads` — large valid payload still round-trips.
- `cargo clippy -p citadel_user --tests` — clean
- `cargo fmt` — clean

## Merge note

Per the repo's strict hybrid auto-merge policy, this touches a protocol/serialization path, so it is marked **[needs-review]** and left open for a human despite being behavior-preserving on the success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtVADqYgNL2Hpb7q3j2DEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtVADqYgNL2Hpb7q3j2DEq)_