### PR TITLE
perf(user): single-pass serialize_into_buf (drop redundant sizing pass)

### DIFF
--- a/citadel_user/src/serialization.rs
+++ b/citadel_user/src/serialization.rs
@@ -132,19 +132,19 @@ pub trait SyncIO {
         })
     }
 
-    /// Serializes self into a buffer
+    /// Serializes self into a buffer, appending to any existing contents.
     fn serialize_into_buf(&self, buf: &mut BytesMut) -> Result<(), AccountError>
     where
         Self: Serialize,
     {
-        bincode::serialized_size(self)
-            .and_then(|amt| {
-                buf.reserve(amt as usize);
-                bincode::serialize_into(buf.writer(), self)
-            })
-            .map_err(|err| {
-                citadel_io::error!(citadel_io::ErrorCode::SerializationFailed, err.to_string())
-            })
+        // Single-pass serialization directly into the buffer. The previous implementation first
+        // called `bincode::serialized_size(self)` to pre-reserve exact capacity, but that is a
+        // full second serialization pass over `self` on every outbound packet (this is invoked by
+        // nearly every packet-crafter). `BytesMut`'s writer already grows amortized, so the sizing
+        // pass was pure CPU overhead. The emitted bytes are byte-for-byte identical to before.
+        bincode::serialize_into(buf.writer(), self).map_err(|err| {
+            citadel_io::error!(citadel_io::ErrorCode::SerializationFailed, err.to_string())
+        })
     }
 
     /// Serializes directly into a slice
@@ -224,6 +224,31 @@ mod tests {
         let mut slice = vec![0u8; size];
         s.serialize_into_slice(&mut slice).unwrap();
         assert_eq!(Sample::deserialize_from_vector(&slice).unwrap(), s);
+    }
+
+    #[test]
+    fn serialize_into_buf_matches_vector_and_appends() {
+        let s = sample();
+        let expected = s.serialize_to_vector().unwrap();
+
+        // Into an empty buffer: output must equal the canonical vector form byte-for-byte
+        // (guards the single-pass optimization against any wire-format drift).
+        let mut buf = BytesMut::new();
+        s.serialize_into_buf(&mut buf).unwrap();
+        assert_eq!(&buf[..], &expected[..]);
+
+        // Into a non-empty buffer: serialization must APPEND, leaving the existing prefix
+        // intact, because packet crafters write a header before the serialized body.
+        let prefix = [0xDEu8, 0xAD, 0xBE, 0xEF];
+        let mut buf = BytesMut::from(&prefix[..]);
+        s.serialize_into_buf(&mut buf).unwrap();
+        assert_eq!(&buf[..prefix.len()], &prefix[..]);
+        assert_eq!(&buf[prefix.len()..], &expected[..]);
+        // The appended body still round-trips independently of the prefix.
+        assert_eq!(
+            Sample::deserialize_from_vector(&buf[prefix.len()..]).unwrap(),
+            s
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`SyncIO::serialize_into_buf` (in `citadel_user/src/serialization.rs`) previously called `bincode::serialized_size(self)` to pre-reserve exact capacity, then `bincode::serialize_into(...)`. `serialized_size` is itself a **full serialization pass**, so every call serialized the value twice. This method is invoked by nearly every packet-crafter in `citadel_proto/src/proto/packet_crafter.rs` (20+ call sites — group headers, acks, payloads, peer commands, etc.), i.e. it's on the outbound datapath.

This PR drops the sizing pass and serializes once directly into the buffer via `buf.writer()`. `BytesMut`'s writer already grows amortized, so the explicit pre-reserve was unnecessary overhead.

## Why

Halves the serialization CPU work for every outbound packet body, with no change to the emitted bytes or to the public API (signature is unchanged).

## Risk

**Low / behavior-preserving.** The emitted bytes are byte-for-byte identical — there is no wire-format change, no protocol/crypto semantic change, and append semantics (header prefix written before the body) are preserved. The only observable difference is allocation timing inside `BytesMut` (amortized growth vs. one exact `reserve`), which is internal.

A new unit test, `serialize_into_buf_matches_vector_and_appends`, locks this in: it asserts the output equals the canonical `serialize_to_vector()` form byte-for-byte and that serialization appends after an existing buffer prefix (and the appended body still round-trips).

## How verified

Locally (Rust 1.94.1):
- `cargo build -p citadel_user` — clean
- `cargo test -p citadel_user --lib serialization` — 5 passed, 0 failed (incl. the new equivalence test)
- `cargo clippy -p citadel_user --tests -- -D warnings` — clean
- `cargo fmt -p citadel_user` — clean

The trait signature is unchanged, so downstream consumers (`citadel_proto`) compile unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmJDaYvLNvRgwFtr6Bwh39

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmJDaYvLNvRgwFtr6Bwh39)_