### PR TITLE
[needs-review] harden(crypt): reject u32 overflow in SecureMessagePacket::write_payload

### DIFF
--- a/citadel_crypt/src/secure_buffer/sec_packet.rs
+++ b/citadel_crypt/src/secure_buffer/sec_packet.rs
@@ -178,7 +178,17 @@ impl<const N: usize> SecureMessagePacket<N> {
     ) -> std::io::Result<()> {
         match self {
             Self::PayloadNext(packet) => {
-                packet.prepare_payload(len + 4)?; // adds 4 for length field
+                // Reserve `len` bytes plus the 4-byte big-endian length prefix. Use a checked add
+                // so a near-`u32::MAX` `len` returns a clean error instead of overflowing: in debug
+                // `len + 4` panics, and in release it wraps to a tiny reservation, after which the
+                // `payload[0..4]` length-prefix write below panics with an out-of-bounds slice.
+                let reserve_len = len.checked_add(4).ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "payload length overflows u32 with the 4-byte length prefix",
+                    )
+                })?;
+                packet.prepare_payload(reserve_len)?; // adds 4 for length field
                 let mut payload = packet.payload()?;
                 BigEndian::write_u32(&mut payload[0..4], len);
                 let ret = (fx)(&mut payload[4..]);
@@ -330,6 +340,20 @@ mod tests {
         // extension before header is rejected
         let p3 = SecureMessagePacket::<4>::new().unwrap();
         assert!(p3.write_payload_extension(1, |_| Ok(())).is_err());
+    }
+
+    #[test]
+    fn write_payload_rejects_length_prefix_overflow() {
+        // `len + 4` (payload + 4-byte length prefix) must not overflow u32. For any `len` in
+        // `(u32::MAX - 4, u32::MAX]` the add overflows; the API must return an InvalidInput error
+        // instead of panicking (debug overflow / release wrap -> out-of-bounds prefix write).
+        for len in [u32::MAX, u32::MAX - 1, u32::MAX - 3] {
+            let mut p = SecureMessagePacket::<4>::new().unwrap();
+            let err = p
+                .write_payload(len, |_| Ok(()))
+                .expect_err("overflowing payload length must be rejected");
+            assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

`SecureMessagePacket::write_payload(len, ..)` reserves `len` bytes for the payload **plus** a 4-byte big-endian length prefix. It computed that reservation with an unchecked `u32` add (`len + 4`).

For any `len` in `(u32::MAX - 4, u32::MAX]` this overflows:

- **debug** builds panic on the overflowing add, and
- **release** builds wrap to a tiny reservation (e.g. `len = u32::MAX` → reserve `3`), after which the very next line — `BigEndian::write_u32(&mut payload[0..4], len)` — panics with an out-of-bounds slice index because the payload window is shorter than 4 bytes.

Either way an oversized payload length turns into a panic in a non-test production path instead of a recoverable error.

This PR replaces the add with `checked_add(4)` that returns `std::io::ErrorKind::InvalidInput` on overflow, and adds a negative test over the overflowing boundary values (`u32::MAX`, `u32::MAX - 1`, `u32::MAX - 3`).

## Why

`write_payload` is a public API on the outbound secure-packet construction path. A panic-on-overflow / panic-on-OOB-slice is a correctness/robustness defect; returning an error is the contractually-correct behavior (the function already returns `io::Result<()>`).

## Risk

Low, and behavior-preserving for all valid inputs:

- For every `len <= u32::MAX - 4`, `checked_add(4)` yields exactly the same value as `len + 4`, so the reservation, the on-wire 4-byte length prefix, and the payload bytes are **byte-for-byte identical**. No wire-format or protocol change.
- Only the previously-panicking overflow edge now returns `InvalidInput` instead of aborting.
- The receive-side counterpart (`extract_payload`) already validates its length field, so this only tightens the send side.

It nonetheless lives in the crypto crate's secure-packet primitive (a security-sensitive path), so it is intentionally marked **[needs-review]** rather than auto-merged, per repo automation policy.

## How verified

- `cargo build -p citadel_crypt` — clean.
- `cargo test -p citadel_crypt --lib secure_buffer::sec_packet` — 5/5 pass, including the new `write_payload_rejects_length_prefix_overflow`.
- `cargo clippy -p citadel_crypt --tests -- -D warnings` — clean.
- `cargo fmt --check -p citadel_crypt` — clean.

(One pre-existing parallelism artifact in the untouched `partitioned_sec_buffer` `should_panic` tests aborts under multi-thread; those tests pass `--test-threads=1`. Unrelated to this change — different file, no production code touched there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6G7paixhGk9kpNZbKLyP9)_