### PR TITLE
[needs-review] harden(crypt): bounds-check remote-controlled wave_id in WAVE_ACK handling

### DIFF
--- a/citadel_crypt/src/scramble/crypt_splitter.rs
+++ b/citadel_crypt/src/scramble/crypt_splitter.rs
@@ -1117,6 +1117,18 @@ impl<const N: usize> GroupSenderDevice<N> {
     /// Frees the RAM internally. Returns true if the entire group is complete
     #[allow(unused_results)]
     pub fn on_wave_tail_ack_received(&mut self, wave_id: u32) -> bool {
+        // `wave_id` is taken verbatim from a remote-peer-controlled WAVE_ACK header and is not
+        // otherwise validated by the caller. Reject out-of-range ids so a malformed/forged ack
+        // cannot (a) overflow the `max_packets_per_wave * wave_id` offset arithmetic — a panic in
+        // debug builds, a silent wrap in release — (b) trip the `get_packets_in_wave` debug_assert,
+        // or (c) inflate the `packets_received` accounting that drives group completion (which would
+        // either prematurely tear the transfer down or wedge it so it never completes). A legitimate
+        // ack always has `wave_id < wave_count`.
+        if wave_id >= self.receiver_config.wave_count {
+            log::warn!(target: "citadel", "Discarding WAVE_ACK for out-of-range wave_id {wave_id} (wave_count={})", self.receiver_config.wave_count);
+            return false;
+        }
+
         let offset = self.receiver_config.max_packets_per_wave * wave_id;
         let packets_in_this_wave = self.get_packets_in_wave(wave_id);
 
@@ -1338,5 +1350,77 @@ mod group_config_validation_tests {
         cfg.max_payload_size = 1;
         cfg.last_payload_size = 1;
         assert!(cfg.validate().is_err());
+    }
+}
+
+#[cfg(test)]
+mod sender_wave_ack_tests {
+    use super::{GroupReceiverConfig, GroupSenderDevice};
+    use citadel_types::proto::ObjectId;
+    use std::collections::HashMap;
+
+    /// Internally-consistent config: wave_count == full + partial == 3.
+    fn valid_config() -> GroupReceiverConfig {
+        let number_of_full_waves = 2u32;
+        let number_of_partial_waves = 1u32;
+        let max_packets_per_wave = 4u32;
+        let packets_in_last_wave = 3u32;
+        GroupReceiverConfig {
+            packets_needed: number_of_full_waves * max_packets_per_wave + packets_in_last_wave,
+            max_packets_per_wave,
+            plaintext_length: 1000,
+            max_payload_size: 100,
+            last_payload_size: 50,
+            number_of_full_waves,
+            number_of_partial_waves,
+            wave_count: number_of_full_waves + number_of_partial_waves,
+            max_plaintext_wave_length: 360,
+            last_plaintext_wave_length: 200,
+            packets_in_last_wave,
+            header_size_bytes: 72,
+            group_id: 0,
+            object_id: ObjectId::from(0u128),
+            transfer_type: None,
+            empty_transfer: false,
+        }
+    }
+
+    fn empty_sender() -> GroupSenderDevice<0> {
+        GroupSenderDevice::<0>::new(valid_config(), HashMap::new())
+    }
+
+    // An out-of-range `wave_id` is rejected without panicking, without overflowing the
+    // `max_packets_per_wave * wave_id` offset arithmetic, and without corrupting the
+    // `packets_received` accounting. Before the bounds check this would overflow-panic in
+    // debug builds and double-count in release.
+    #[test]
+    fn out_of_range_wave_ack_is_ignored() {
+        let cfg = valid_config();
+        for bad_wave_id in [cfg.wave_count, cfg.wave_count + 1, u32::MAX] {
+            let mut sender = empty_sender();
+            assert!(
+                !sender.on_wave_tail_ack_received(bad_wave_id),
+                "out-of-range wave_id {bad_wave_id} must not report group completion"
+            );
+            assert_eq!(
+                sender.get_packets_received(),
+                0,
+                "out-of-range wave_id {bad_wave_id} must not advance the received counter"
+            );
+        }
+    }
+
+    // A legitimate (in-range) ack is still accepted and advances accounting as before.
+    #[test]
+    fn in_range_wave_ack_still_accounts() {
+        let cfg = valid_config();
+        let mut sender = empty_sender();
+        // ack the (in-range) final wave: 3 packets, not the whole group, so not complete yet.
+        let complete = sender.on_wave_tail_ack_received(cfg.wave_count - 1);
+        assert!(!complete);
+        assert_eq!(
+            sender.get_packets_received(),
+            cfg.packets_in_last_wave as usize
+        );
     }
 }


### PR DESCRIPTION
## What

`GroupSenderDevice::on_wave_tail_ack_received` (citadel_crypt) used the `wave_id` argument
verbatim to index per-wave bookkeeping. That argument flows directly from a **remote-peer-controlled
WAVE_ACK packet header**: `citadel_proto`'s `on_wave_ack_received` forwards `header.wave_id.get()`
into it without validating the id against the transfer's `wave_count`.

This PR rejects out-of-range ids at the top of the function (a legitimate ack always has
`wave_id < wave_count`) and adds regression tests.

```rust
if wave_id >= self.receiver_config.wave_count {
    log::warn!(target: "citadel", "Discarding WAVE_ACK for out-of-range wave_id ...");
    return false;
}
```

## Why (threat model)

With an out-of-range `wave_id`, a malformed or forged WAVE_ACK could:

- **Overflow the offset arithmetic** — `max_packets_per_wave * wave_id` (and `offset + packets_in_wave`)
  is `u32 * u32`. For a large `wave_id` this panics in debug builds and silently wraps in release.
- **Trip a debug_assert** — `get_packets_in_wave` has `debug_assert!(wave_id < wave_count)`.
- **Corrupt completion accounting** — `packets_received += packets_in_this_wave` is incremented for a
  bogus wave, which can either make `packets_received == packets_needed` fire early (premature teardown)
  or overshoot it so the group never registers as complete (wedged transfer / leaked sender state).

This is a small, contained robustness fix on the file-transfer send path against an
attacker-influenced input.

## Risk

Low, but **security/protocol-adjacent** — it changes how a session-state component reacts to an
inbound protocol header, so per the repo's merge policy I've left it **open with `[needs-review]`**
rather than auto-merging. The change is purely additive (an early-return guard); legitimate acks
(`wave_id < wave_count`) are completely unaffected.

Noted as out of scope / possible follow-ups (valid-but-out-of-order or duplicate acks):
`get_next_packet`'s `remove(...).unwrap()` and the non-idempotent double-count on a repeated valid
`wave_id`. Kept this PR to the single bounds check to stay reviewable.

## How verified

- `cargo build -p citadel_crypt`
- `cargo test -p citadel_crypt --lib sender_wave_ack` — new tests pass:
  - `out_of_range_wave_ack_is_ignored` (rejects `wave_count`, `wave_count+1`, `u32::MAX`; no panic, counter stays 0)
  - `in_range_wave_ack_still_accounts` (an in-range ack still advances accounting)
- `cargo clippy -p citadel_crypt --tests -- -D warnings` — clean
- `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G6kPTUpmmk45oCJHA8xBCT

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6kPTUpmmk45oCJHA8xBCT)_