### PR TITLE
harden(netbeam): drop orphaned response slot when TrackedCallbackChannel send fails

### DIFF
--- a/netbeam/src/sync/tracked_callback_channel.rs
+++ b/netbeam/src/sync/tracked_callback_channel.rs
@@ -142,6 +142,10 @@ impl<T: Send + Sync, R: Send + Sync> TrackedCallbackChannel<T, R> {
             })
             .await
             .map_err(|_| {
+                // The downstream channel is gone, so this request can never be answered. Drop the
+                // response slot we just registered; otherwise every send() against a dead channel
+                // would orphan a oneshot Sender in `map`, growing it without bound (resource leak).
+                self.inner.map.lock().remove(&id);
                 TrackedCallbackError::channel_send("tracked callback channel send failed")
             })?;
 
@@ -261,6 +265,29 @@ mod tests {
         let client = citadel_io::tokio::spawn(client);
 
         let (_, _) = citadel_io::tokio::join!(server, client);
+    }
+
+    #[tokio::test]
+    async fn send_on_dead_channel_does_not_leak_slot() {
+        // Regression: `send()` registers a response slot in `map` *before* pushing onto the
+        // mpsc channel. If that push fails (receiver dropped), the early return must still
+        // remove the slot, otherwise a dead channel accumulates orphaned oneshot senders.
+        citadel_logging::setup_log();
+        let (tx, rx) = TrackedCallbackChannel::<u32, u64>::new(10);
+        // Drop the receiver so every subsequent send fails at the mpsc layer.
+        drop(rx);
+
+        for x in 0..16 {
+            assert!(
+                tx.send(x).await.is_err(),
+                "send must fail once the receiver is gone"
+            );
+        }
+
+        assert!(
+            tx.inner.map.lock().is_empty(),
+            "failed sends must not orphan response slots in the tracking map"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`TrackedCallbackChannel::send` registers the oneshot response `Sender` in the tracking `map` **before** pushing the payload onto the inner mpsc channel:

```rust
self.inner.map.lock().insert(next_value, tx);   // slot registered
// ...
self.inner.to_channel.send(...).await
    .map_err(|_| TrackedCallbackError::channel_send("..."))?;  // early return on failure
```

If that push fails (the `CallbackReceiver` has been dropped / the channel is closed), the `?` returned early **without removing the slot it just inserted**. Each subsequent `send()` against a dead channel then orphaned another oneshot `Sender` in `map`, growing it without bound.

This change removes the slot on the send-failure path.

## Why

- **Resource leak / unbounded growth.** A long-lived `TrackedCallbackChannel` (it is `Clone` + `Arc`-backed, so senders can outlive the receiver) whose receiver has gone away accumulates one orphaned `HashMap` entry per failed `send()`. Each entry pins a `tokio::sync::oneshot::Sender<R>`.
- The type's own module docs promise *"Memory-efficient response tracking with cleanup"* — the leak silently violated that contract.
- The sibling `CallbackChannel` is **not** affected: it carries the oneshot sender inside the payload tuple, so a failed send drops it naturally. Only the *tracked* variant keeps the sender in a side map and so needs explicit cleanup.

## Risk

Low. The change is confined to the error path of one function and only fires when the channel send already failed (request is unanswerable anyway). No protocol, wire-format, session-state, or crypto behavior is touched — this is a pure resource-hygiene fix in an internal sync utility.

## How verified

- Added regression test `send_on_dead_channel_does_not_leak_slot`: drops the receiver, drives 16 failing sends, asserts the tracking map stays empty.
- Confirmed the test **fails before** the fix (`failed sends must not orphan response slots in the tracking map`) and **passes after**.
- `cargo build -p netbeam`, `cargo test -p netbeam --lib sync::tracked_callback_channel` (4 passed), `cargo clippy -p netbeam --tests -- -D warnings` (clean), `cargo fmt` (no changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXQTRdVs91rrPiwRKqArRu)_