### PR TITLE
feat(netbeam): n-node fault-tolerant NetGroupMutex/NetGroupRwLock group locks

### DIFF
--- a/citadel_crypt/src/ratchets/mono/keys.rs
+++ b/citadel_crypt/src/ratchets/mono/keys.rs
@@ -83,7 +83,7 @@ impl std::fmt::Debug for FcmKeys {
         write!(
             f,
             "api key: {} || client ID: : {}",
-            &self.api_key, &self.client_id
+            self.api_key, self.client_id
         )
     }
 }

--- a/citadel_crypt/tests/primary.rs
+++ b/citadel_crypt/tests/primary.rs
@@ -799,7 +799,7 @@ mod tests {
 
             let config = scramble_transmitter.get_receiver_config();
             let mut receiver = GroupReceiver::new(config.clone(), 0, 0);
-            log::trace!(target: "citadel", "{:?}", &config);
+            log::trace!(target: "citadel", "{:?}", config);
 
             while let Some(packet) = scramble_transmitter.get_next_packet() {
                 let _result = receiver.on_packet_received(

--- a/citadel_proto/src/kernel/kernel_executor.rs
+++ b/citadel_proto/src/kernel/kernel_executor.rs
@@ -204,7 +204,7 @@ impl<K: NetKernel<R>, R: Ratchet> KernelExecutor<K, R> {
                     message => {
                         callback_handler.on_message_received(message, |message| async move {
                             if let Err(err) = kernel_ref.on_node_event_received(message).await {
-                                log::error!(target: "citadel", "Kernel threw an error: {:?}. Will end", &err);
+                                log::error!(target: "citadel", "Kernel threw an error: {:?}. Will end", err);
                                 // calling this will cause server_to_kernel_rx to receive a shutdown message
                                 citadel_server_remote.clone().shutdown().await?;
                                 Err(err)

--- a/citadel_proto/src/proto/misc/native_connect.rs
+++ b/citadel_proto/src/proto/misc/native_connect.rs
@@ -52,7 +52,7 @@ pub async fn c2s_connect(
             external_addr,
             is_self_signed,
         } => {
-            log::trace!(target: "citadel", "Host claims OrderedReliableSecure (TLS) CONNECTION (domain: {:?}) | External ADDR: {:?} | self-signed? {}", &domain, external_addr, is_self_signed);
+            log::trace!(target: "citadel", "Host claims OrderedReliableSecure (TLS) CONNECTION (domain: {:?}) | External ADDR: {:?} | self-signed? {}", domain, external_addr, is_self_signed);
 
             // Only fall back to the accept-any-cert connector when the server advertises self-signed
             // AND the local client policy permits it. Otherwise an active attacker could flip
@@ -85,7 +85,7 @@ pub async fn c2s_connect(
             external_addr,
             is_self_signed,
         } => {
-            log::trace!(target: "citadel", "Host claims P2P (QUIC) CONNECTION (domain: {:?}) | External ADDR: {:?} | self-signed: {}", &domain, external_addr, is_self_signed);
+            log::trace!(target: "citadel", "Host claims P2P (QUIC) CONNECTION (domain: {:?}) | External ADDR: {:?} | self-signed: {}", domain, external_addr, is_self_signed);
             let signal = QuicRedirectSignal {
                 domain,
                 external_addr,

--- a/citadel_proto/src/proto/misc/native_io_udp.rs
+++ b/citadel_proto/src/proto/misc/native_io_udp.rs
@@ -176,7 +176,7 @@ async fn listen_udp_port<R: Ratchet, S: crate::proto::misc::udp_internal_interfa
     while let Some(res) = stream.next().await {
         match res {
             Ok((packet, remote_peer)) => {
-                log::trace!(target: "citadel", "Packet received on port {} has {} bytes (src: {:?})", local_port, packet.len(), &remote_peer);
+                log::trace!(target: "citadel", "Packet received on port {} has {} bytes (src: {:?})", local_port, packet.len(), remote_peer);
                 let packet = HdpPacket::new_recv(packet, remote_peer, local_port);
                 this.process_inbound_packet_udp(packet, &peer_session_accessor)?;
             }
@@ -214,7 +214,7 @@ async fn udp_outbound_sender<R: Ratchet, S: futures::SinkExt<bytes::Bytes> + Unp
                 SecurityLevel::Standard,
             )
         })?;
-        log::trace!(target: "citadel", "About to send packet w/len {} | Dest: {:?}", packet.len(), &send_addr);
+        log::trace!(target: "citadel", "About to send packet w/len {} | Dest: {:?}", packet.len(), send_addr);
         sink.send(packet.freeze())
             .await
             .map_err(|_| error!(ErrorCode::UdpSinkRecvFailed))?;

--- a/citadel_proto/src/proto/misc/net.rs
+++ b/citadel_proto/src/proto/misc/net.rs
@@ -535,7 +535,7 @@ impl QuicListener {
                 acceptor_stream
                     .try_for_each_concurrent(None, |(conn, tx, rx)| async move {
                         let addr = conn.remote_address();
-                        log::trace!(target: "citadel", "RECV {:?} from {:?}", &conn, addr);
+                        log::trace!(target: "citadel", "RECV {:?} from {:?}", conn, addr);
                         send.send(Ok((conn, tx, rx, addr, endpoint.clone())))
                             .await
                             .map_err(generic_error)

--- a/citadel_proto/src/proto/node.rs
+++ b/citadel_proto/src/proto/node.rs
@@ -239,7 +239,7 @@ impl<R: Ratchet, T: PlatformOps> CitadelNode<R, T> {
             let res = if let Some(primary_stream_listener) = primary_stream_listener {
                 citadel_io::tokio::select! {
                     res0 = outbound_kernel_request_handler => {
-                        log::trace!(target: "citadel", "OUTBOUND KERNEL REQUEST HANDLER ENDED: {:?}", &res0);
+                        log::trace!(target: "citadel", "OUTBOUND KERNEL REQUEST HANDLER ENDED: {:?}", res0);
                         res0
                     }
 
@@ -249,7 +249,7 @@ impl<R: Ratchet, T: PlatformOps> CitadelNode<R, T> {
             } else {
                 citadel_io::tokio::select! {
                     res0 = outbound_kernel_request_handler => {
-                        log::trace!(target: "citadel", "OUTBOUND KERNEL REQUEST HANDLER ENDED: {:?}", &res0);
+                        log::trace!(target: "citadel", "OUTBOUND KERNEL REQUEST HANDLER ENDED: {:?}", res0);
                         res0
                     }
 

--- a/citadel_proto/src/proto/node_result.rs
+++ b/citadel_proto/src/proto/node_result.rs
@@ -275,7 +275,6 @@ impl<R: Ratchet> NodeResult<R> {
                         error: err,
                         peer_connection_type: _,
                     },
-                ticket: _,
                 ..
             }) => Err(NetworkError::generic(err)),
             res => Ok(res),

--- a/citadel_proto/src/proto/packet_processor/connect_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/connect_packet.rs
@@ -259,7 +259,7 @@ pub async fn process_connect<R: Ratchet, T: PlatformOps>(
                 {
                     let message = String::from_utf8(payload.message.to_vec())
                         .unwrap_or_else(|_| "Invalid UTF-8 message".to_string());
-                    log::error!(target: "citadel", "The server refused to login the user. Reason: {}", &message);
+                    log::error!(target: "citadel", "The server refused to login the user. Reason: {}", message);
                     let cid = ratchet.get_cid();
                     state_container.connect_state.on_fail();
                     drop(state_container);
@@ -348,7 +348,7 @@ pub async fn process_connect<R: Ratchet, T: PlatformOps>(
                                 return Ok(PrimaryProcessorResult::EndSession("Unable to upgrade from a provisional to a protected connection (Client)"));
                             }
 
-                            log::trace!(target: "citadel", "The login to the server was a success. Welcome Message: {}", &message);
+                            log::trace!(target: "citadel", "The login to the server was a success. Welcome Message: {}", message);
 
                             let post_login_object = payload.post_login_object.clone();
                             //session.post_quantum = pqc;

--- a/citadel_proto/src/proto/packet_processor/peer/peer_cmd_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/peer/peer_cmd_packet.rs
@@ -260,7 +260,7 @@ pub async fn process_peer_cmd<R: Ratchet, T: PlatformOps>(
                                 }
 
                                 Err(err) => {
-                                    log::error!(target: "citadel", "Unable to register at endpoints: {:?}", &err);
+                                    log::error!(target: "citadel", "Unable to register at endpoints: {:?}", err);
                                     to_kernel.unbounded_send(NodeResult::PeerEvent(PeerEvent {
                                         event: PeerSignal::SignalError {
                                             ticket,
@@ -607,7 +607,7 @@ pub async fn process_peer_cmd<R: Ratchet, T: PlatformOps>(
                                             .generate_proper_listener_connect_addr(
                                                 &session.local_nat_type,
                                             );
-                                        log::trace!(target: "citadel", "[STUN] Peer public addr: {:?} || needs TURN? {}", &bob_predicted_socket_addr, needs_turn);
+                                        log::trace!(target: "citadel", "[STUN] Peer public addr: {:?} || needs TURN? {}", bob_predicted_socket_addr, needs_turn);
                                         let udp_rx_opt = kem_state.udp_channel_sender.rx.take();
                                         let local_is_file_transfer_compat = session
                                             .account_manager
@@ -825,7 +825,7 @@ pub async fn process_peer_cmd<R: Ratchet, T: PlatformOps>(
                                             .get_backend_type()
                                             .is_filesystem_backend();
 
-                                        log::trace!(target: "citadel", "[STUN] Peer public addr: {:?} || needs TURN? {}", &alice_predicted_socket_addr, needs_turn);
+                                        log::trace!(target: "citadel", "[STUN] Peer public addr: {:?} || needs TURN? {}", alice_predicted_socket_addr, needs_turn);
 
                                         let p2p_connection_id = kem.p2p_connection_id;
                                         let channel = match state_container

--- a/citadel_proto/src/proto/packet_processor/raw_primary_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/raw_primary_packet.rs
@@ -68,7 +68,7 @@ pub async fn process_raw_packet<R: Ratchet, T: PlatformOps>(
         return Ok(PrimaryProcessorResult::Void);
     }
 
-    log::trace!(target: "citadel", "RECV Raw packet: {:?}", &packet.parse().unwrap().0);
+    log::trace!(target: "citadel", "RECV Raw packet: {:?}", packet.parse().unwrap().0);
     let (header, _payload) = return_if_none!(packet.parse(), "Unable to parse packet");
 
     let target_cid = header.target_cid.get();

--- a/citadel_proto/src/proto/peer/p2p_conn_handler.rs
+++ b/citadel_proto/src/proto/peer/p2p_conn_handler.rs
@@ -225,7 +225,7 @@ mod native_p2p {
             .ok_or_else(|| generic_error("P2P Stream did not have QUIC connection loaded"))?;
         let udp_conn = QuicUdpSocketConnector::new(quic_conn, local_bind_addr);
 
-        log::trace!(target: "citadel", "[P2P-stream {}] New stream from {:?}", from_listener.if_true("listener").if_false("client"), &remote_peer);
+        log::trace!(target: "citadel", "[P2P-stream {}] New stream from {:?}", from_listener.if_true("listener").if_false("client"), remote_peer);
         let (sink, stream) = misc::safe_split_stream(p2p_stream);
         let (p2p_primary_stream_tx, p2p_primary_stream_rx) = unbounded();
         let p2p_primary_stream_tx = OutboundPrimaryStreamSender::from(p2p_primary_stream_tx);

--- a/citadel_proto/src/proto/peer/peer_layer.rs
+++ b/citadel_proto/src/proto/peer/peer_layer.rs
@@ -467,7 +467,7 @@ impl<R: Ratchet> CitadelNodePeerLayerInner<R> {
     ) -> Option<Ticket> {
         log::trace!(target: "citadel", "Checking simultaneous register between {session_cid} and {peer_cid}");
 
-        self.check_simultaneous_event(peer_cid, |posting| if let PeerSignal::PostConnect { peer_conn_type: conn, ticket_opt: _, invitee_response: _, session_security_settings: _, udp_mode: _, .. } = &posting.signal {
+        self.check_simultaneous_event(peer_cid, |posting| if let PeerSignal::PostConnect { peer_conn_type: conn, .. } = &posting.signal {
             log::trace!(target: "citadel", "Checking if posting from conn={conn:?} ~ {session_cid:?}");
             if let PeerConnectionType::LocalGroupPeer { session_cid: _, peer_cid: b } = conn {
                 *b == session_cid

--- a/citadel_proto/src/proto/session.rs
+++ b/citadel_proto/src/proto/session.rs
@@ -1445,7 +1445,7 @@ impl<R: Ratchet, T: PlatformOps> CitadelSession<R, T> {
 
             let mut state_container = inner_mut_state!(this.state_container);
 
-            log::trace!(target: "citadel", "Transmit file name: {}", &file_name);
+            log::trace!(target: "citadel", "Transmit file name: {}", file_name);
             // the key cid must be differentiated from the target cid because the target_cid needs to be zero if
             // there is no proxying. the key cid cannot be zero; if client -> server, key uses implicated cid
             let (
@@ -1846,7 +1846,7 @@ impl<R: Ratchet, T: PlatformOps> CitadelSession<R, T> {
                                     }
                                 }
                             } else {
-                                log::warn!(target: "citadel", "Attempted to remove {:?}, but was already absent from map", &file_key);
+                                log::warn!(target: "citadel", "Attempted to remove {:?}, but was already absent from map", file_key);
                             }
 
                             if kernel_tx2.unbounded_send(NodeResult::InternalServerError(InternalServerError {

--- a/citadel_proto/src/proto/session_manager.rs
+++ b/citadel_proto/src/proto/session_manager.rs
@@ -1127,7 +1127,7 @@ impl<R: Ratchet, T: PlatformOps> CitadelSessionManager<R, T> {
 
         let left_signal = match peer_layer.remove_peers_from_message_group(key, peers).await {
             Ok((peers_removed, peers_remaining)) => {
-                log::trace!(target: "citadel", "Peers removed: {:?}", &peers_removed);
+                log::trace!(target: "citadel", "Peers removed: {:?}", peers_removed);
                 // We only notify the members when kicking, not leaving
                 if mode == GroupMemberAlterMode::Kick {
                     // notify all the peers removed

--- a/citadel_proto/src/proto/validation.rs
+++ b/citadel_proto/src/proto/validation.rs
@@ -450,7 +450,7 @@ pub(crate) mod aead {
             header_bytes,
             &mut payload,
         ) {
-            log::error!(target: "citadel", "AES-GCM stage failed: {:?}. Supplied Ratchet Version: {} | Expected Ratchet Version: {} | Header CID: {} | Target CID: {}\nPacket: {:?}\nPayload len: {}", err, ratchet.version(), header.entropy_bank_version.get(), header.session_cid.get(), header.target_cid.get(), &header, payload.len());
+            log::error!(target: "citadel", "AES-GCM stage failed: {:?}. Supplied Ratchet Version: {} | Expected Ratchet Version: {} | Header CID: {} | Target CID: {}\nPacket: {:?}\nPayload len: {}", err, ratchet.version(), header.entropy_bank_version.get(), header.session_cid.get(), header.target_cid.get(), header, payload.len());
             return None;
         }
 

--- a/citadel_proto/tests/connections.rs
+++ b/citadel_proto/tests/connections.rs
@@ -95,7 +95,7 @@ pub mod tests {
         }
 
         for proto in protocols {
-            log::trace!(target: "citadel", "Testing proto {:?} @ {:?}", &proto, addr);
+            log::trace!(target: "citadel", "Testing proto {:?} @ {:?}", proto, addr);
 
             let res = NativeIO::bind(proto.clone(), addr).await;
 
@@ -160,7 +160,7 @@ pub mod tests {
 
         let count = 32; // keep this value low to ensure that runners don't get exhausted and run out of FD's
         for proto in protocols {
-            log::trace!(target: "citadel", "Testing proto {:?}", &proto);
+            log::trace!(target: "citadel", "Testing proto {:?}", proto);
             let cnt = &AtomicUsize::new(0);
 
             let res = NativeIO::bind(proto.clone(), addr).await;

--- a/citadel_sdk/src/prefabs/client/broadcast.rs
+++ b/citadel_sdk/src/prefabs/client/broadcast.rs
@@ -349,7 +349,6 @@ where
             match event.into_result()? {
                 NodeResult::PeerEvent(PeerEvent {
                     event: ref ps @ PeerSignal::PostRegister { .. },
-                    ticket: _,
                     ..
                 }) => {
                     shared
@@ -417,7 +416,6 @@ impl<F, Fut, R: Ratchet> NetKernel<R> for BroadcastKernel<'_, F, Fut, R> {
     async fn on_node_event_received(&self, message: NodeResult<R>) -> Result<(), NetworkError> {
         if let NodeResult::PeerEvent(PeerEvent {
             event: ps @ PeerSignal::PostRegister { .. },
-            ticket: _,
             ..
         }) = &message
         {

--- a/citadel_sdk/src/remote_ext.rs
+++ b/citadel_sdk/src/remote_ext.rs
@@ -505,7 +505,6 @@ pub trait ProtocolRemoteExt<R: Ratchet>: Remote<R> {
                         response: Some(PeerResponse::RegisteredCids(peer_info, is_onlines)),
                         limit: _,
                     },
-                ticket: _,
                 ..
             }) = status.into_result()?
             {
@@ -555,7 +554,6 @@ pub trait ProtocolRemoteExt<R: Ratchet>: Remote<R> {
                         v_conn_type: _,
                         response: Some(PeerResponse::RegisteredCids(peer_info, is_onlines)),
                     },
-                ticket: _,
                 ..
             }) = status.into_result()?
             {
@@ -976,7 +974,6 @@ pub trait ProtocolRemoteTargetExt<R: Ratchet>: TargetLockedRemote<R> {
                         ticket_opt: _,
                         invitee_response: Some(resp),
                     },
-                ticket: _,
                 ..
             }) = status.into_result()?
             {
@@ -1013,7 +1010,6 @@ pub trait ProtocolRemoteTargetExt<R: Ratchet>: TargetLockedRemote<R> {
             while let Some(result) = subscription.next().await {
                 if let NodeResult::PeerEvent(PeerEvent {
                     event: PeerSignal::DeregistrationSuccess { .. },
-                    ticket: _,
                     ..
                 }) = result.into_result()?
                 {
@@ -1081,7 +1077,6 @@ pub trait ProtocolRemoteTargetExt<R: Ratchet>: TargetLockedRemote<R> {
                                 disconnect_response: Some(_),
                                 ..
                             },
-                        ticket: _,
                         ..
                     }) = event.into_result()?
                     {

--- a/citadel_sdk/tests/stress_tests.rs
+++ b/citadel_sdk/tests/stress_tests.rs
@@ -610,11 +610,11 @@ mod tests {
         if let Err(err) = &res {
             match err {
                 futures::future::Either::Left(left) => {
-                    log::warn!(target: "citadel", "ERR-left: {:?}", &left.0);
+                    log::warn!(target: "citadel", "ERR-left: {:?}", left.0);
                 }
 
                 futures::future::Either::Right(right) => {
-                    log::warn!(target: "citadel", "ERR-right: {:?}", &right.0);
+                    log::warn!(target: "citadel", "ERR-right: {:?}", right.0);
                 }
             }
         }

--- a/citadel_user/src/account_manager.rs
+++ b/citadel_user/src/account_manager.rs
@@ -416,7 +416,7 @@ impl<R: Ratchet, Fcm: Ratchet> AccountManager<R, Fcm> {
         adjacent_username: T,
     ) -> Result<(), AccountError> {
         let adjacent_username = adjacent_username.into();
-        log::trace!(target: "citadel", "Registering {} ({}) to {} (local/endpoints)", &adjacent_username, peer_cid, session_cid);
+        log::trace!(target: "citadel", "Registering {} ({}) to {} (local/endpoints)", adjacent_username, peer_cid, session_cid);
         self.persistence_handler
             .register_p2p_as_client(session_cid, peer_cid, adjacent_username)
             .await

--- a/citadel_user/src/auth/proposed_credentials.rs
+++ b/citadel_user/src/auth/proposed_credentials.rs
@@ -307,7 +307,7 @@ impl ProposedCredentials {
                     }
 
                     ArgonStatus::VerificationFailed(Some(err)) => {
-                        log::error!(target: "citadel", "Password verification failed: {}", &err);
+                        log::error!(target: "citadel", "Password verification failed: {}", err);
                         Err(AccountError::generic(err))
                     }
 

--- a/citadel_wire/src/standard/quic.rs
+++ b/citadel_wire/src/standard/quic.rs
@@ -504,7 +504,7 @@ mod tests {
             start_tx.send(()).unwrap();
             let (conn, _tx, mut rx) = server.next_connection().await.unwrap();
             let addr = conn.remote_address();
-            log::trace!(target: "citadel", "RECV {:?} from {:?}", &conn, addr);
+            log::trace!(target: "citadel", "RECV {:?} from {:?}", conn, addr);
             let buf = &mut [0u8; 3];
             rx.read(buf as &mut [u8]).await.unwrap();
             assert_eq!(buf, &[1, 2, 3]);

--- a/citadel_wire/src/standard/socket_helpers.rs
+++ b/citadel_wire/src/standard/socket_helpers.rs
@@ -189,7 +189,7 @@ fn get_udp_socket_inner<T: std::net::ToSocketAddrs>(
 
     let addr = localhost_testing_addr_fix(addr);
 
-    log::trace!(target: "citadel", "[Socket helper] Getting UDP (reuse={}) socket @ {:?} ...", reuse, &addr);
+    log::trace!(target: "citadel", "[Socket helper] Getting UDP (reuse={}) socket @ {:?} ...", reuse, addr);
     let domain = if addr.is_ipv4() {
         Domain::IPV4
     } else {
@@ -229,7 +229,7 @@ fn get_tcp_listener_inner<T: std::net::ToSocketAddrs>(
 
     let addr = localhost_testing_addr_fix(addr);
 
-    log::trace!(target: "citadel", "[Socket helper] Getting TCP listener (reuse={}) socket @ {:?} ...", reuse, &addr);
+    log::trace!(target: "citadel", "[Socket helper] Getting TCP listener (reuse={}) socket @ {:?} ...", reuse, addr);
 
     let domain = if addr.is_ipv4() {
         Domain::IPV4
@@ -254,7 +254,7 @@ async fn get_tcp_stream_inner<T: std::net::ToSocketAddrs>(
         .to_socket_addrs()?
         .next()
         .ok_or_else(|| anyhow::Error::msg("Bad socket addr"))?;
-    log::trace!(target: "citadel", "[Socket helper] Getting TCP connect (reuse={}) socket to {:?} ...", reuse, &addr);
+    log::trace!(target: "citadel", "[Socket helper] Getting TCP connect (reuse={}) socket to {:?} ...", reuse, addr);
     //return Ok(citadel_io::TcpStream::connect(addr).await?)
     let domain = if addr.is_ipv4() {
         Domain::IPV4
@@ -329,7 +329,7 @@ mod tests {
         let server = citadel_io::tokio::task::spawn(async move {
             log::trace!(target: "citadel", "Starting server @ {addr:?}");
             let (mut conn, addr) = server.accept().await.unwrap();
-            log::trace!(target: "citadel", "RECV {:?} from {:?}", &conn, addr);
+            log::trace!(target: "citadel", "RECV {:?} from {:?}", conn, addr);
             let buf = &mut [0u8; 3];
             conn.read_exact(buf as &mut [u8]).await.unwrap();
             assert_eq!(buf, &[1, 2, 3]);

--- a/citadel_wire/src/udp_traversal/hole_punched_socket.rs
+++ b/citadel_wire/src/udp_traversal/hole_punched_socket.rs
@@ -128,7 +128,7 @@ impl Display for TargettedSocketAddr {
         writeln!(
             f,
             "(Original, Natted): {:?} -> {:?}",
-            &self.send_address, &self.receive_address
+            self.send_address, self.receive_address
         )
     }
 }

--- a/citadel_wire/src/udp_traversal/linear/method3.rs
+++ b/citadel_wire/src/udp_traversal/linear/method3.rs
@@ -126,7 +126,7 @@ impl Method3 {
         id: HolePunchID,
     ) -> Option<TargettedSocketAddr> {
         let lock = self.observed_addrs_on_syn.lock();
-        log::trace!(target: "citadel", "Recv'd SYNS: {:?}", &*lock);
+        log::trace!(target: "citadel", "Recv'd SYNS: {:?}", *lock);
         lock.get(&id).copied()
     }
 
@@ -311,7 +311,7 @@ impl Method3 {
         loop {
             match socket.recv_from(buf).await {
                 Ok((len, peer_external_addr)) => {
-                    log::trace!(target: "citadel", "[UDP Hole-punch] RECV packet from {:?} | {:?}", &peer_external_addr, &buf[..len]);
+                    log::trace!(target: "citadel", "[UDP Hole-punch] RECV packet from {:?} | {:?}", peer_external_addr, &buf[..len]);
                     let packet = match encryptor.decrypt_packet(&buf[..len]) {
                         Some(plaintext) => plaintext,
                         _ => {
@@ -416,7 +416,7 @@ impl Method3 {
                                 peer_external_addr,
                                 adjacent_unique_id,
                             );
-                            log::trace!(target: "citadel", "***UDP Hole-punch to {:?} success!***", &hole_punched_addr);
+                            log::trace!(target: "citadel", "***UDP Hole-punch to {:?} success!***", hole_punched_addr);
                             socket.stop_outgoing_traffic().await;
 
                             return Ok(hole_punched_addr);

--- a/citadel_wire/src/udp_traversal/linear/mod.rs
+++ b/citadel_wire/src/udp_traversal/linear/mod.rs
@@ -142,7 +142,7 @@ impl SingleUDPHolePuncher {
                 let unique_id = self.unique_id;
                 let hole_punched_addr =
                     TargettedSocketAddr::new(peer_external_addr, natted_socket, unique_id);
-                log::trace!(target: "citadel", "[UPnP] {}", &hole_punched_addr);
+                log::trace!(target: "citadel", "[UPnP] {}", hole_punched_addr);
 
                 Ok(HolePunchedUdpSocket {
                     addr: hole_punched_addr,

--- a/deny.toml
+++ b/deny.toml
@@ -91,7 +91,10 @@ exceptions = [
     # attohttpc
     { allow = ["MPL-2.0"], name = "attohttpc", version = "*" },
     # this is for testing only, which is not part of the SDK
-    { allow = ["MPL-2.0", "CDLA-Permissive-2.0"], name = "webpki-roots", version = "*" }
+    { allow = ["MPL-2.0", "CDLA-Permissive-2.0"], name = "webpki-roots", version = "*" },
+    # transitive via quinn-proto -> fastbloom. Zlib is a permissive, OSI-approved,
+    # FSF-Free license (BSD-like: no attribution or copyleft obligations)
+    { allow = ["Zlib"], name = "foldhash", version = "*" }
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/firebase-rtdb/src/lib.rs
+++ b/firebase-rtdb/src/lib.rs
@@ -322,7 +322,7 @@ impl FirebaseRTDB {
             .await
             .map_err(|e| RtdbError::rtdb(e.to_string()))?;
 
-        log::trace!(target: "citadel", "RESP RENEW: {:?}", &resp);
+        log::trace!(target: "citadel", "RESP RENEW: {:?}", resp);
         // update internal value using the new response
         let expire_time = Instant::now()
             + Duration::from_secs(
@@ -390,7 +390,7 @@ impl Node<'_> {
     pub fn child<T: AsRef<str>>(&mut self, child: T) -> &mut Self {
         self.string_builder += child.as_ref();
         self.string_builder += "/";
-        log::trace!(target: "citadel", "Builder: {:?}", &self.string_builder);
+        log::trace!(target: "citadel", "Builder: {:?}", self.string_builder);
         self
     }
 
@@ -401,7 +401,7 @@ impl Node<'_> {
     pub fn final_node<T: AsRef<str>>(&mut self, node: T) -> &Self {
         self.string_builder += node.as_ref();
         self.string_builder += ".json";
-        log::trace!(target: "citadel", "Builder: {:?}", &self.string_builder);
+        log::trace!(target: "citadel", "Builder: {:?}", self.string_builder);
         self
     }
 

--- a/netbeam/src/sync/channel/bi_channel.rs
+++ b/netbeam/src/sync/channel/bi_channel.rs
@@ -267,7 +267,7 @@ impl<T: NetObject, S: Subscribable + 'static> Drop for ChannelRecvHalf<T, S> {
                 // wait for halt verified packet
                 loop {
                     let packet = chan.recv_serialized::<ChannelPacket<T>>().await?;
-                    log::trace!(target: "citadel", "[Drop RECV] on {:?} recv {:?}", chan.node_type(), &packet);
+                    log::trace!(target: "citadel", "[Drop RECV] on {:?} recv {:?}", chan.node_type(), packet);
 
                     if let ChannelPacket::<T>::HaltVerified = packet {
                         break

--- a/netbeam/src/sync/group/acceptor.rs
+++ b/netbeam/src/sync/group/acceptor.rs
@@ -1,0 +1,188 @@
+//! The per-member consensus voter: a timerless two-transition Paxos acceptor.
+//! All lock semantics live in [`crate::sync::group::ops::apply`] at the proposer;
+//! the acceptor only orders proposals. Quorum intersection over acceptors is the
+//! entire safety argument.
+
+use crate::sync::group::record::LockRecord;
+use crate::sync::group::wire::Ballot;
+use crate::sync::group::LockId;
+use serde::{Deserialize, Serialize};
+
+/// Durable acceptor state. With the default [`EphemeralAcceptorStore`] the group is
+/// safe under CRASH-STOP failures only: a voter that restarts with amnesia could
+/// re-promise below an earlier promise and break quorum intersection. Consumers that
+/// need voters to survive restart must persist this state via a durable
+/// [`AcceptorStateStore`] (write-before-reply).
+#[derive(Serialize, Deserialize, Clone, Debug, Default, Eq, PartialEq)]
+pub struct PersistedAcceptor {
+    pub promised: Option<Ballot>,
+    pub accepted: Option<(Ballot, LockRecord)>,
+}
+
+/// Reply to a `Prepare`.
+#[derive(Clone, Debug)]
+pub enum PrepareReply {
+    Promise {
+        accepted: Option<(Ballot, LockRecord)>,
+    },
+    Nack {
+        promised: Ballot,
+    },
+}
+
+/// Reply to an `Accept`.
+#[derive(Clone, Debug)]
+pub enum AcceptReply {
+    Accepted,
+    Nack { promised: Ballot },
+}
+
+/// The pure acceptor. `on_prepare`/`on_accept` are the only two transitions.
+#[derive(Default, Clone, Debug)]
+pub struct Acceptor {
+    state: PersistedAcceptor,
+}
+
+impl Acceptor {
+    pub fn from_persisted(state: PersistedAcceptor) -> Self {
+        Self { state }
+    }
+
+    pub fn state(&self) -> &PersistedAcceptor {
+        &self.state
+    }
+
+    pub fn on_prepare(&mut self, ballot: Ballot) -> PrepareReply {
+        match self.state.promised {
+            Some(promised) if ballot <= promised => PrepareReply::Nack { promised },
+            _ => {
+                self.state.promised = Some(ballot);
+                PrepareReply::Promise {
+                    accepted: self.state.accepted.clone(),
+                }
+            }
+        }
+    }
+
+    pub fn on_accept(&mut self, ballot: Ballot, record: LockRecord) -> AcceptReply {
+        match self.state.promised {
+            Some(promised) if ballot < promised => AcceptReply::Nack { promised },
+            _ => {
+                self.state.promised = Some(ballot);
+                self.state.accepted = Some((ballot, record));
+                AcceptReply::Accepted
+            }
+        }
+    }
+
+    /// Non-linearizable read of the highest accepted record (a hint only; every
+    /// decision that matters re-validates through a CAS round).
+    pub fn read_hint(&self) -> Option<(Ballot, LockRecord)> {
+        self.state.accepted.clone()
+    }
+}
+
+/// Persistence hook for acceptor state. Implementations must make `save` durable
+/// BEFORE the acceptor's reply is sent to preserve promise monotonicity across
+/// restarts. The in-memory [`EphemeralAcceptorStore`] declares, by its name, that
+/// restarts are NOT survivable (crash-stop model).
+pub trait AcceptorStateStore: Send + Sync + 'static {
+    fn load(&self, lock: LockId) -> Option<PersistedAcceptor>;
+    fn save(&self, lock: LockId, state: &PersistedAcceptor);
+}
+
+/// In-memory store: voters are safe under crash-stop (a crashed member must not
+/// rejoin as a voter). The explicit name is the API-level warning.
+#[derive(Default)]
+pub struct EphemeralAcceptorStore {
+    states: citadel_io::RwLock<std::collections::HashMap<LockId, PersistedAcceptor>>,
+}
+
+impl AcceptorStateStore for EphemeralAcceptorStore {
+    fn load(&self, lock: LockId) -> Option<PersistedAcceptor> {
+        self.states.read().get(&lock).cloned()
+    }
+
+    fn save(&self, lock: LockId, state: &PersistedAcceptor) {
+        let _ = self.states.write().insert(lock, state.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::group::MemberId;
+
+    fn ballot(counter: u64, member: u64) -> Ballot {
+        Ballot {
+            counter,
+            proposer: MemberId(member),
+        }
+    }
+
+    #[test]
+    fn promise_ordering() {
+        let mut acc = Acceptor::default();
+        assert!(matches!(
+            acc.on_prepare(ballot(2, 1)),
+            PrepareReply::Promise { .. }
+        ));
+        // lower and equal ballots are refused
+        assert!(matches!(
+            acc.on_prepare(ballot(1, 9)),
+            PrepareReply::Nack { .. }
+        ));
+        assert!(matches!(
+            acc.on_prepare(ballot(2, 1)),
+            PrepareReply::Nack { .. }
+        ));
+        // higher counter or same counter from higher member id wins
+        assert!(matches!(
+            acc.on_prepare(ballot(2, 2)),
+            PrepareReply::Promise { .. }
+        ));
+    }
+
+    #[test]
+    fn accept_below_promise_rejected_but_repromote_allowed() {
+        let mut acc = Acceptor::default();
+        let rec = LockRecord::initial(vec![1]);
+        acc.on_prepare(ballot(5, 1));
+        assert!(matches!(
+            acc.on_accept(ballot(4, 9), rec.clone()),
+            AcceptReply::Nack { .. }
+        ));
+        // accept at exactly the promised ballot succeeds
+        assert!(matches!(
+            acc.on_accept(ballot(5, 1), rec.clone()),
+            AcceptReply::Accepted
+        ));
+        // a *higher* accept also succeeds (functions as an implicit promise)
+        assert!(matches!(
+            acc.on_accept(ballot(6, 1), rec.clone()),
+            AcceptReply::Accepted
+        ));
+        assert_eq!(acc.read_hint().unwrap().0, ballot(6, 1));
+        // and afterwards, prepares below that implicit promise are refused
+        assert!(matches!(
+            acc.on_prepare(ballot(6, 1)),
+            PrepareReply::Nack { .. }
+        ));
+    }
+
+    #[test]
+    fn promise_returns_highest_accepted() {
+        let mut acc = Acceptor::default();
+        let rec = LockRecord::initial(vec![7]);
+        acc.on_prepare(ballot(1, 1));
+        acc.on_accept(ballot(1, 1), rec.clone());
+        match acc.on_prepare(ballot(2, 2)) {
+            PrepareReply::Promise { accepted } => {
+                let (b, r) = accepted.unwrap();
+                assert_eq!(b, ballot(1, 1));
+                assert_eq!(r, rec);
+            }
+            other => panic!("expected promise, got {other:?}"),
+        }
+    }
+}

--- a/netbeam/src/sync/group/acquire.rs
+++ b/netbeam/src/sync/group/acquire.rs
@@ -1,0 +1,179 @@
+//! The acquire flow: immediate grant, FIFO wait loop (nudge + poll backstop),
+//! janitor duty (steal stagnant holders / evict stagnant waiters that block us),
+//! and deadline cancellation.
+//!
+//! Lease anchoring rule: a grant's `valid_until` is anchored at the local instant
+//! the round that *could have committed it* was started — never later — so the
+//! holder's own validity always expires before any observer's steal window opens.
+
+use crate::sync::group::acquire_wait::grant_from;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::engine_util::ms;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::lease::ObservationWindow;
+use crate::sync::group::op_types::{Op, OpDenied, OpOutcome};
+use crate::sync::group::proposer::ProposeError;
+use crate::sync::group::record::PoisonInfo;
+use crate::sync::group::{Fence, LockKind};
+use std::time::Duration;
+
+/// A committed grant, ready to be wrapped in a typed guard.
+pub(crate) struct Grant {
+    pub nonce: u64,
+    pub fence: Fence,
+    pub recovered: Option<PoisonInfo>,
+    pub value: Vec<u8>,
+    pub value_version: Fence,
+    pub valid_until_ms: u64,
+}
+
+impl Engine {
+    pub(crate) async fn acquire(
+        &self,
+        kind: LockKind,
+        no_enqueue: bool,
+        timeout: Duration,
+    ) -> Result<Grant, GroupLockError> {
+        let nonce = rand::random::<u64>();
+        let anchor_ms = self.now_ms();
+        let deadline_ms = anchor_ms + timeout.as_millis() as u64;
+        let op = Op::AcquireOrEnqueue {
+            member: self.me(),
+            nonce,
+            kind,
+            no_enqueue,
+        };
+        match self.propose(&op, deadline_ms).await {
+            Ok((rec, OpOutcome::Granted { fence, recovered })) => {
+                Ok(grant_from(&rec, nonce, fence, recovered, anchor_ms, self))
+            }
+            Ok((_, OpOutcome::Enqueued { .. })) => {
+                self.wait_for_grant(nonce, kind, anchor_ms, deadline_ms)
+                    .await
+            }
+            Ok((_, other)) => Err(GroupLockError::Io(format!(
+                "unexpected acquire outcome: {other:?}"
+            ))),
+            Err(ProposeError::Denied(denied, _)) => Err(super::engine::denial_to_error(denied)),
+            Err(ProposeError::QuorumUnavailable) => Err(GroupLockError::QuorumUnavailable),
+        }
+    }
+
+    /// Enqueued: wait for a nudge (or the poll backstop), refresh our entry
+    /// (waiter heartbeat), claim when admissible, and janitor whatever blocks us.
+    async fn wait_for_grant(
+        &self,
+        nonce: u64,
+        kind: LockKind,
+        enqueue_anchor_ms: u64,
+        deadline_ms: u64,
+    ) -> Result<Grant, GroupLockError> {
+        let steal_window_ms = ms(self
+            .cfg
+            .lease_duration()
+            .saturating_add(self.cfg.steal_grace()));
+        let mut window: Option<ObservationWindow> = None;
+
+        loop {
+            if self.now_ms() >= deadline_ms {
+                return self.cancel_request(nonce).await;
+            }
+            self.wait_for_wake(deadline_ms).await;
+
+            // heartbeat our queue entry; the committed record this returns doubles
+            // as our view for claiming and janitor observation
+            let refresh = Op::RefreshWait {
+                member: self.me(),
+                nonce,
+            };
+            let record = match self.propose(&refresh, deadline_ms).await {
+                Ok((rec, _)) => rec,
+                Err(ProposeError::Denied(OpDenied::NotQueued, Some(rec))) => {
+                    if let Some(h) = rec.holder(self.me(), nonce) {
+                        // an earlier ambiguous round actually granted us the lock
+                        let (fence, recovered) = (h.fence, h.recovered.clone());
+                        return Ok(grant_from(
+                            &rec,
+                            nonce,
+                            fence,
+                            recovered,
+                            enqueue_anchor_ms,
+                            self,
+                        ));
+                    }
+                    // we were evicted while slow: re-enqueue (fairness hiccup only)
+                    match self.re_enqueue(nonce, kind, deadline_ms).await? {
+                        Some(grant) => return Ok(grant),
+                        None => continue,
+                    }
+                }
+                Err(ProposeError::Denied(denied, _)) => {
+                    return Err(super::engine::denial_to_error(denied))
+                }
+                Err(ProposeError::QuorumUnavailable) => {
+                    return Err(GroupLockError::QuorumUnavailable)
+                }
+            };
+
+            // claim when the write-preferring FIFO rule admits us
+            let admissible =
+                crate::sync::group::admission::is_admissible(&record, self.me(), nonce);
+            log::trace!(target: "citadel", "[GroupLock] {:?} wake: admissible={admissible} holders={:?} qlen={}", self.me(), record.holders, record.queue.len());
+            if admissible {
+                let claim_anchor_ms = self.now_ms();
+                let claim = Op::ClaimQueued {
+                    member: self.me(),
+                    nonce,
+                };
+                match self.propose(&claim, deadline_ms).await {
+                    Ok((rec, OpOutcome::Granted { fence, recovered })) => {
+                        return Ok(grant_from(
+                            &rec,
+                            nonce,
+                            fence,
+                            recovered,
+                            claim_anchor_ms,
+                            self,
+                        ))
+                    }
+                    Ok((_, other)) => {
+                        return Err(GroupLockError::Io(format!(
+                            "unexpected claim outcome: {other:?}"
+                        )))
+                    }
+                    Err(ProposeError::Denied(OpDenied::NotAdmissible, _)) => {
+                        // raced another commit; observe again next wake
+                        continue;
+                    }
+                    Err(ProposeError::Denied(OpDenied::NotQueued, Some(rec))) => {
+                        if let Some(h) = rec.holder(self.me(), nonce) {
+                            let (fence, recovered) = (h.fence, h.recovered.clone());
+                            return Ok(grant_from(
+                                &rec,
+                                nonce,
+                                fence,
+                                recovered,
+                                claim_anchor_ms,
+                                self,
+                            ));
+                        }
+                        match self.re_enqueue(nonce, kind, deadline_ms).await? {
+                            Some(grant) => return Ok(grant),
+                            None => continue,
+                        }
+                    }
+                    Err(ProposeError::Denied(denied, _)) => {
+                        return Err(super::engine::denial_to_error(denied))
+                    }
+                    Err(ProposeError::QuorumUnavailable) => {
+                        return Err(GroupLockError::QuorumUnavailable)
+                    }
+                }
+            }
+
+            // janitor: watch whatever blocks us; steal/evict after a full frozen window
+            self.janitor(&record, nonce, &mut window, steal_window_ms, deadline_ms)
+                .await;
+        }
+    }
+}

--- a/netbeam/src/sync/group/acquire_wait.rs
+++ b/netbeam/src/sync/group/acquire_wait.rs
@@ -1,0 +1,123 @@
+//! Support routines for the acquire wait loop: wake timing, janitor duty
+//! (steal/evict stagnant blockers), re-enqueue after eviction, and deadline
+//! cancellation.
+
+use crate::sync::group::acquire::Grant;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::engine_util::deadline;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::lease::{blocking_snapshot, BlockerSnapshot, ObservationWindow};
+use crate::sync::group::op_types::{Op, OpOutcome};
+use crate::sync::group::proposer::ProposeError;
+use crate::sync::group::record::{LockRecord, PoisonInfo};
+use crate::sync::group::{Fence, LockKind};
+use std::time::Duration;
+
+impl Engine {
+    pub(super) async fn wait_for_wake(&self, deadline_ms: u64) {
+        let remaining = deadline_ms.saturating_sub(self.now_ms());
+        let nap = self
+            .cfg
+            .waiter_poll_interval()
+            .min(Duration::from_millis(remaining.max(1)));
+        citadel_io::tokio::select! {
+            _ = self.nudge.notified() => {}
+            _ = citadel_io::time::sleep(nap) => {}
+        }
+    }
+
+    pub(super) async fn janitor(
+        &self,
+        record: &LockRecord,
+        nonce: u64,
+        window: &mut Option<ObservationWindow>,
+        steal_window_ms: u64,
+        deadline_ms: u64,
+    ) {
+        let now = self.now_ms();
+        let Some(snap) = blocking_snapshot(record, self.me(), nonce) else {
+            *window = None;
+            return;
+        };
+        let w = window.get_or_insert_with(|| ObservationWindow::start(snap, now));
+        let stagnant = w.observe(snap, now);
+        if !(stagnant && w.is_expired(now, steal_window_ms)) {
+            return;
+        }
+        log::trace!(target: "citadel", "[GroupLock] {:?} janitor firing on {:?}", self.me(), w.snapshot());
+        let op = match *w.snapshot() {
+            BlockerSnapshot::Holder {
+                member,
+                nonce: target_nonce,
+                fence,
+                lease_seq,
+            } => Op::Steal {
+                target: member,
+                target_nonce,
+                expect_fence: fence,
+                expect_lease_seq: lease_seq,
+            },
+            BlockerSnapshot::Waiter {
+                member,
+                nonce: target_nonce,
+                refresh_seq,
+            } => Op::EvictWaiter {
+                target: member,
+                target_nonce,
+                expect_refresh_seq: refresh_seq,
+            },
+        };
+        // outcome irrelevant: TargetGone/SnapshotMismatch simply mean the blocker
+        // moved; the next wake re-evaluates from the committed record
+        let _ = self.propose(&op, deadline_ms).await;
+        *window = None;
+    }
+
+    pub(super) async fn re_enqueue(
+        &self,
+        nonce: u64,
+        kind: LockKind,
+        deadline_ms: u64,
+    ) -> Result<Option<Grant>, GroupLockError> {
+        let anchor_ms = self.now_ms();
+        let op = Op::AcquireOrEnqueue {
+            member: self.me(),
+            nonce,
+            kind,
+            no_enqueue: false,
+        };
+        match self.propose(&op, deadline_ms).await {
+            Ok((rec, OpOutcome::Granted { fence, recovered })) => Ok(Some(grant_from(
+                &rec, nonce, fence, recovered, anchor_ms, self,
+            ))),
+            Ok(_) => Ok(None),
+            Err(ProposeError::Denied(denied, _)) => Err(super::engine::denial_to_error(denied)),
+            Err(ProposeError::QuorumUnavailable) => Err(GroupLockError::QuorumUnavailable),
+        }
+    }
+
+    /// Deadline expired while queued: withdraw the request. If the cancel raced a
+    /// grant, the pure Dequeue op already revoked it poison-free.
+    pub(super) async fn cancel_request(&self, nonce: u64) -> Result<Grant, GroupLockError> {
+        self.best_effort_dequeue(nonce).await;
+        Err(GroupLockError::Timeout)
+    }
+}
+
+pub(super) fn grant_from(
+    record: &LockRecord,
+    nonce: u64,
+    fence: Fence,
+    recovered: Option<PoisonInfo>,
+    anchor_ms: u64,
+    engine: &Engine,
+) -> Grant {
+    Grant {
+        nonce,
+        fence,
+        recovered,
+        value: record.value.clone(),
+        value_version: record.value_version,
+        valid_until_ms: deadline(anchor_ms, engine.cfg.lease_duration()),
+    }
+}

--- a/netbeam/src/sync/group/admission.rs
+++ b/netbeam/src/sync/group/admission.rs
@@ -1,0 +1,175 @@
+//! Write-preferring FIFO admission rule (the etcd RWMutex / tokio::sync::RwLock policy),
+//! the single source of truth for both `NetGroupMutex` and `NetGroupRwLock`:
+//!
+//! - a WRITE entry is admissible iff nothing is held and it is the queue head
+//!   (a writer waits on ANY earlier entry);
+//! - a READ entry is admissible iff the lock is free or held by readers AND no write
+//!   entry is queued ahead of it (a reader waits only on earlier writers);
+//!
+//! hence the admissible readers at any instant are exactly the queue prefix before the
+//! first queued writer — reader *batching* falls out, and a queued writer blocks every
+//! later reader, so writers cannot starve.
+
+use crate::sync::group::record::{Holders, LockRecord, WaitEntry};
+use crate::sync::group::{LockKind, MemberId};
+
+/// Whether the queue entry `(member, nonce)` could be granted right now.
+pub fn is_admissible(record: &LockRecord, member: MemberId, nonce: u64) -> bool {
+    let Some((idx, entry)) = record.wait_entry(member, nonce) else {
+        return false;
+    };
+    match entry.kind {
+        LockKind::Write => matches!(record.holders, Holders::None) && idx == 0,
+        LockKind::Read => {
+            let holders_compatible = matches!(record.holders, Holders::None | Holders::Readers(_));
+            holders_compatible
+                && !record.queue[..idx]
+                    .iter()
+                    .any(|w| w.kind == LockKind::Write)
+        }
+    }
+}
+
+/// Whether a brand-new request (not yet queued) could be granted immediately,
+/// i.e. admissibility as if appended at the queue tail.
+pub fn immediate_grant_allowed(record: &LockRecord, kind: LockKind) -> bool {
+    match kind {
+        LockKind::Write => matches!(record.holders, Holders::None) && record.queue.is_empty(),
+        LockKind::Read => {
+            matches!(record.holders, Holders::None | Holders::Readers(_))
+                && !record.queue.iter().any(|w| w.kind == LockKind::Write)
+        }
+    }
+}
+
+/// The members whose queue entries just became (or may have become) admissible —
+/// the targets a releaser nudges. Returns either the head writer or the whole
+/// reader prefix, never both (no herd effect).
+pub fn next_grants(record: &LockRecord) -> Vec<MemberId> {
+    let mut targets: Vec<MemberId> = Vec::new();
+    match record.queue.first().map(|w| w.kind) {
+        Some(LockKind::Write) => {
+            if matches!(record.holders, Holders::None) {
+                targets.push(record.queue[0].member);
+            }
+        }
+        Some(LockKind::Read) => {
+            if matches!(record.holders, Holders::None | Holders::Readers(_)) {
+                for w in reader_prefix(record) {
+                    if !targets.contains(&w.member) {
+                        targets.push(w.member);
+                    }
+                }
+            }
+        }
+        None => {}
+    }
+    targets
+}
+
+fn reader_prefix(record: &LockRecord) -> impl Iterator<Item = &WaitEntry> {
+    record.queue.iter().take_while(|w| w.kind == LockKind::Read)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::group::record::HolderEntry;
+    use crate::sync::group::Fence;
+
+    fn wait(member: u64, nonce: u64, kind: LockKind) -> WaitEntry {
+        WaitEntry {
+            member: MemberId(member),
+            nonce,
+            kind,
+            refresh_seq: 0,
+        }
+    }
+
+    fn holder(member: u64) -> HolderEntry {
+        HolderEntry {
+            member: MemberId(member),
+            nonce: 0,
+            fence: Fence(1),
+            lease_seq: 0,
+            recovered: None,
+        }
+    }
+
+    fn record(holders: Holders, queue: Vec<WaitEntry>) -> LockRecord {
+        let mut r = LockRecord::initial(vec![]);
+        r.holders = holders;
+        r.queue = queue;
+        r
+    }
+
+    #[test]
+    fn writer_admissible_only_at_head_of_free_lock() {
+        let r = record(
+            Holders::None,
+            vec![wait(1, 1, LockKind::Write), wait(2, 2, LockKind::Write)],
+        );
+        assert!(is_admissible(&r, MemberId(1), 1));
+        assert!(!is_admissible(&r, MemberId(2), 2));
+
+        let r = record(
+            Holders::Readers(vec![holder(3)]),
+            vec![wait(1, 1, LockKind::Write)],
+        );
+        assert!(!is_admissible(&r, MemberId(1), 1));
+    }
+
+    #[test]
+    fn reader_blocked_by_earlier_writer_only() {
+        let r = record(
+            Holders::None,
+            vec![
+                wait(1, 1, LockKind::Read),
+                wait(2, 2, LockKind::Write),
+                wait(3, 3, LockKind::Read),
+            ],
+        );
+        assert!(is_admissible(&r, MemberId(1), 1));
+        assert!(!is_admissible(&r, MemberId(3), 3)); // behind the queued writer
+    }
+
+    #[test]
+    fn readers_batch_alongside_current_readers() {
+        let r = record(
+            Holders::Readers(vec![holder(9)]),
+            vec![wait(1, 1, LockKind::Read), wait(2, 2, LockKind::Read)],
+        );
+        assert!(is_admissible(&r, MemberId(1), 1));
+        assert!(is_admissible(&r, MemberId(2), 2));
+        assert_eq!(next_grants(&r), vec![MemberId(1), MemberId(2)]);
+    }
+
+    #[test]
+    fn immediate_grant_respects_write_preference() {
+        let free = record(Holders::None, vec![]);
+        assert!(immediate_grant_allowed(&free, LockKind::Write));
+        assert!(immediate_grant_allowed(&free, LockKind::Read));
+
+        // a queued writer bars new readers even while readers hold the lock
+        let r = record(
+            Holders::Readers(vec![holder(9)]),
+            vec![wait(1, 1, LockKind::Write)],
+        );
+        assert!(!immediate_grant_allowed(&r, LockKind::Read));
+        assert!(!immediate_grant_allowed(&r, LockKind::Write));
+    }
+
+    #[test]
+    fn next_grants_head_writer_when_free() {
+        let r = record(
+            Holders::None,
+            vec![wait(2, 2, LockKind::Write), wait(1, 1, LockKind::Read)],
+        );
+        assert_eq!(next_grants(&r), vec![MemberId(2)]);
+        let held = record(
+            Holders::Writer(holder(9)),
+            vec![wait(2, 2, LockKind::Write)],
+        );
+        assert!(next_grants(&held).is_empty());
+    }
+}

--- a/netbeam/src/sync/group/adversary_tests.rs
+++ b/netbeam/src/sync/group/adversary_tests.rs
@@ -1,0 +1,248 @@
+//! Directed adversarial tests: each scenario mounts a specific attack on a safety
+//! property — stale ballots, dueling proposers, forged accepts, stale steal snapshots,
+//! fenced-out zombies, write-preference bypass, re-init, voter amnesia — and asserts
+//! the protocol's defense. Pure and synchronous: no I/O, no clocks, no tokio.
+use super::acceptor::{AcceptReply, Acceptor, PrepareReply};
+use super::op_types::{Op, OpDenied, OpOutcome};
+use super::ops::apply;
+use super::record::{HolderEntry, Holders, LockRecord};
+use super::wire::Ballot;
+use super::{Fence, LockKind, MemberId};
+
+const N: usize = 5;
+const QUORUM: usize = N / 2 + 1;
+const ALL: [usize; N] = [0, 1, 2, 3, 4];
+
+fn ballot(counter: u64, member: u64) -> Ballot {
+    Ballot {
+        counter,
+        proposer: MemberId(member),
+    }
+}
+
+#[rustfmt::skip]
+fn acquire(m: u64, nonce: u64, kind: LockKind, no_enqueue: bool) -> Op {
+    Op::AcquireOrEnqueue { member: MemberId(m), nonce, kind, no_enqueue }
+}
+#[rustfmt::skip]
+fn renew(m: u64, nonce: u64, f: Fence, s: u64) -> Op {
+    Op::Renew { member: MemberId(m), nonce, expect_fence: f, expect_lease_seq: s }
+}
+#[rustfmt::skip]
+fn release(m: u64, nonce: u64, f: Fence, v: Option<Vec<u8>>) -> Op {
+    Op::Release { member: MemberId(m), nonce, expect_fence: f, new_value: v }
+}
+#[rustfmt::skip]
+fn steal(t: u64, n: u64, f: Fence, s: u64) -> Op {
+    Op::Steal { target: MemberId(t), target_nonce: n, expect_fence: f, expect_lease_seq: s }
+}
+
+/// Applies `ops` in order onto a freshly initialized record, unwrapping every step.
+fn state(ops: &[Op]) -> LockRecord {
+    let mut rec = apply(None, &Op::Init { value: vec![9] }).unwrap().0;
+    for op in ops {
+        rec = apply(Some(&rec), op).unwrap().0;
+    }
+    rec
+}
+
+fn writer(rec: &LockRecord) -> HolderEntry {
+    match &rec.holders {
+        Holders::Writer(h) => h.clone(),
+        other => panic!("expected writer, got {other:?}"),
+    }
+}
+
+struct Cluster(Vec<Acceptor>);
+
+impl Cluster {
+    fn new() -> Self {
+        let mut c = Self(vec![Acceptor::default(); N]);
+        let init = c.round(&ALL, ballot(1, 0), &Op::Init { value: vec![] });
+        assert!(init.is_some(), "bootstrap init must commit");
+        c
+    }
+
+    /// One CASPaxos round restricted to the acceptors in `q`; `None` = failed round.
+    fn round(&mut self, q: &[usize], b: Ballot, op: &Op) -> Option<LockRecord> {
+        let (mut votes, mut promised) = (0, Vec::new());
+        for &i in q {
+            if let PrepareReply::Promise { accepted } = self.0[i].on_prepare(b) {
+                votes += 1;
+                promised.extend(accepted);
+            }
+        }
+        (votes >= QUORUM).then_some(())?;
+        let base = promised
+            .into_iter()
+            .max_by_key(|(bb, _)| *bb)
+            .map(|(_, r)| r);
+        let rec = apply(base.as_ref(), op).ok()?.0;
+        let mut acks = 0;
+        for &i in q {
+            let reply = self.0[i].on_accept(b, rec.clone());
+            acks += matches!(reply, AcceptReply::Accepted) as usize;
+        }
+        (acks >= QUORUM).then_some(rec)
+    }
+
+    /// The record any future reader adopts: the highest-ballot accepted state.
+    fn read(&self) -> LockRecord {
+        let best = (0..N)
+            .filter_map(|i| self.0[i].read_hint())
+            .max_by_key(|(b, _)| *b);
+        best.unwrap().1
+    }
+}
+
+#[test]
+fn stale_ballot_cannot_overwrite_committed_state() {
+    let mut c = Cluster::new();
+    let op = acquire(1, 10, LockKind::Write, false);
+    let rec = c.round(&ALL, ballot(2, 1), &op).unwrap();
+    // a laggard's lower-ballot prepare is refused by every voter
+    for i in ALL {
+        assert!(matches!(
+            c.0[i].on_prepare(ballot(1, 4)),
+            PrepareReply::Nack { .. }
+        ));
+    }
+    // a forged direct accept below the promise is refused and changes nothing
+    let forged = state(&[acquire(4, 99, LockKind::Write, false)]);
+    for i in ALL {
+        let reply = c.0[i].on_accept(ballot(1, 4), forged.clone());
+        assert!(matches!(reply, AcceptReply::Nack { .. }));
+    }
+    assert_eq!(c.read(), rec);
+}
+
+#[test]
+fn dueling_proposers_cannot_double_grant_write() {
+    let mut c = Cluster::new();
+    let (b1, b2) = (ballot(5, 1), ballot(6, 2));
+    // P1 prepares on the left quorum only
+    for i in [0, 1, 2] {
+        assert!(matches!(
+            c.0[i].on_prepare(b1),
+            PrepareReply::Promise { .. }
+        ));
+    }
+    // P2 runs a complete higher-ballot round on the right quorum and commits
+    let won = c.round(&[2, 3, 4], b2, &acquire(2, 22, LockKind::Write, false));
+    assert!(won.is_some());
+    // P1, unaware, pushes its own conflicting write grant: the intersection voter
+    // refuses, so P1 cannot reach quorum and its round dies
+    let g1 = state(&[acquire(1, 11, LockKind::Write, false)]);
+    let mut acks = 0;
+    for i in [0, 1, 2] {
+        acks += matches!(c.0[i].on_accept(b1, g1.clone()), AcceptReply::Accepted) as usize;
+    }
+    assert!(acks < QUORUM, "stale accept must be refused");
+    // every reader adopts P2's grant; P1's phantom write is unreachable
+    let fin = c.read();
+    assert!(matches!(&fin.holders, Holders::Writer(h) if h.member == MemberId(2)));
+    assert!(fin.holder(MemberId(1), 11).is_none());
+    assert!(fin.wait_entry(MemberId(1), 11).is_none());
+}
+
+#[test]
+fn steal_with_stale_snapshot_is_rejected() {
+    let w = acquire(1, 10, LockKind::Write, false);
+    let h = writer(&state(std::slice::from_ref(&w)));
+    // the holder proves liveness by renewing; the attacker's frozen snapshot is stale
+    let rec = state(&[w, renew(1, 10, h.fence, 0)]);
+    let denied = apply(Some(&rec), &steal(1, 10, h.fence, 0)).unwrap_err();
+    assert_eq!(denied, OpDenied::SnapshotMismatch);
+    // a current snapshot (genuinely dead holder) still succeeds
+    assert!(apply(Some(&rec), &steal(1, 10, h.fence, 1)).is_ok());
+}
+
+#[test]
+fn stolen_writer_is_fully_fenced_out() {
+    let w = acquire(1, 10, LockKind::Write, false);
+    let base = state(std::slice::from_ref(&w));
+    let h = writer(&base);
+    let (rec, out) = apply(Some(&base), &steal(1, 10, h.fence, 0)).unwrap();
+    assert_eq!(out, OpOutcome::Stolen);
+    assert!(rec.poisoned.is_some());
+    // the victim's renew and mutating release are refused; its value never publishes
+    let d1 = apply(Some(&rec), &renew(1, 10, h.fence, 0)).unwrap_err();
+    let d2 = apply(Some(&rec), &release(1, 10, h.fence, Some(vec![0xEE]))).unwrap_err();
+    assert_eq!((d1, d2), (OpDenied::NotHolder, OpDenied::NotHolder));
+    assert_eq!(rec.value_version, Fence(0));
+    // the next write grant reports the recovered poison exactly, then clears it
+    let (rec2, out2) = apply(Some(&rec), &acquire(2, 20, LockKind::Write, false)).unwrap();
+    let ok = matches!(&out2, OpOutcome::Granted { recovered: Some(p), .. }
+        if p.member == MemberId(1) && p.fence == h.fence);
+    assert!(ok, "got {out2:?}");
+    assert!(rec2.poisoned.is_none());
+}
+
+#[test]
+fn write_preference_cannot_be_bypassed_by_readers() {
+    // a reader holds and a writer queues; later readers must not sneak past it
+    let rec = state(&[
+        acquire(1, 1, LockKind::Read, false),
+        acquire(2, 2, LockKind::Write, false),
+    ]);
+    let d = apply(Some(&rec), &acquire(3, 3, LockKind::Read, true)).unwrap_err();
+    assert_eq!(d, OpDenied::WouldBlock);
+    let (rec, out) = apply(Some(&rec), &acquire(3, 3, LockKind::Read, false)).unwrap();
+    assert!(matches!(out, OpOutcome::Enqueued { .. }));
+    // claiming ahead of the queued writer is inadmissible
+    let claim = Op::ClaimQueued {
+        member: MemberId(3),
+        nonce: 3,
+    };
+    assert_eq!(
+        apply(Some(&rec), &claim).unwrap_err(),
+        OpDenied::NotAdmissible
+    );
+}
+
+#[test]
+fn reinit_cannot_reset_the_lock() {
+    let rec = state(&[acquire(1, 10, LockKind::Write, false)]);
+    let denied = apply(Some(&rec), &Op::Init { value: vec![] }).unwrap_err();
+    assert_eq!(denied, OpDenied::AlreadyInitialized);
+}
+
+#[test]
+fn cancel_replay_cannot_double_restore_poison() {
+    // member2's write grant consumed the poison left by stealing member1
+    let w1 = acquire(1, 10, LockKind::Write, false);
+    let f1 = writer(&state(std::slice::from_ref(&w1))).fence;
+    let w2 = acquire(2, 20, LockKind::Write, false);
+    let rec = state(&[w1, steal(1, 10, f1, 0), w2]);
+    // cancel-races-grant: the dequeue revokes the grant and restores the poison once
+    let dq = Op::Dequeue {
+        member: MemberId(2),
+        nonce: 20,
+    };
+    let (rec, out) = apply(Some(&rec), &dq).unwrap();
+    assert_eq!(out, OpOutcome::Dequeued { was_granted: true });
+    assert_eq!(rec.poisoned.as_ref().map(|p| p.member), Some(MemberId(1)));
+    // replaying the cancel is inert: no double restore, no state change
+    assert_eq!(apply(Some(&rec), &dq).unwrap_err(), OpDenied::NotQueued);
+}
+
+/// Executable form of the `EphemeralAcceptorStore` warning: a voter restarting with
+/// amnesia re-promises below its earlier promise (breaking quorum intersection under
+/// crash-RECOVERY), while restoring the persisted snapshot preserves monotonicity —
+/// exactly what a durable `AcceptorStateStore` (write-before-reply) exists for.
+#[test]
+fn amnesiac_voter_forgets_promises_but_persisted_state_does_not() {
+    let mut acc = Acceptor::default();
+    acc.on_prepare(ballot(5, 1));
+    let saved = acc.state().clone();
+    let mut amnesiac = Acceptor::default(); // crash + restart without persistence
+    assert!(matches!(
+        amnesiac.on_prepare(ballot(3, 2)),
+        PrepareReply::Promise { .. }
+    ));
+    let mut restored = Acceptor::from_persisted(saved);
+    assert!(matches!(
+        restored.on_prepare(ballot(3, 2)),
+        PrepareReply::Nack { .. }
+    ));
+}

--- a/netbeam/src/sync/group/config.rs
+++ b/netbeam/src/sync/group/config.rs
@@ -1,0 +1,234 @@
+//! Explicit configuration for a group lock. Every field is required (no `Default`):
+//! lease/timing values are safety-liveness tradeoffs the caller must choose consciously.
+
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::{fnv1a, MemberId};
+use std::time::Duration;
+
+/// Configuration shared by every member of one lock group. All members MUST construct
+/// an identical config (same members, owner, and durations); a digest of the config
+/// travels in every packet and mismatching packets are dropped, so a misconfigured
+/// deployment fails fast instead of silently running split semantics.
+#[derive(Clone, Debug)]
+pub struct GroupLockConfig {
+    members: Vec<MemberId>,
+    local_id: MemberId,
+    initial_value_owner: MemberId,
+    lease_duration: Duration,
+    renew_interval: Duration,
+    steal_grace: Duration,
+    acquire_timeout: Duration,
+    round_timeout: Duration,
+    cas_backoff_base: Duration,
+    waiter_poll_interval: Duration,
+    digest: u64,
+}
+
+impl GroupLockConfig {
+    /// All parameters are mandatory.
+    ///
+    /// - `members`: full static membership (deduplicated, order-insensitive), `n >= 2`.
+    /// - `local_id`: this process's member id; must be in `members`.
+    /// - `initial_value_owner`: the member that supplies the initial value; must be in `members`.
+    /// - `lease_duration`: how long a grant stays valid without a successful renew.
+    /// - `renew_interval`: cadence of holder renews; must be `< lease_duration / 2`.
+    /// - `steal_grace`: extra margin observers wait beyond `lease_duration` before
+    ///   stealing a stagnant holder (absorbs clock-rate skew + renew-round latency).
+    /// - `acquire_timeout`: default bound for `lock()`/`read()`/`write()`.
+    /// - `round_timeout`: how long one consensus round waits for a majority of replies.
+    /// - `cas_backoff_base`: base delay (±50% jitter) between dueling-proposer retries.
+    /// - `waiter_poll_interval`: waiter re-poll cadence (nudge-loss backstop and
+    ///   waiter heartbeat via queue-entry refresh).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        members: Vec<MemberId>,
+        local_id: MemberId,
+        initial_value_owner: MemberId,
+        lease_duration: Duration,
+        renew_interval: Duration,
+        steal_grace: Duration,
+        acquire_timeout: Duration,
+        round_timeout: Duration,
+        cas_backoff_base: Duration,
+        waiter_poll_interval: Duration,
+    ) -> Result<Self, GroupLockError> {
+        let mut members = members;
+        members.sort_unstable();
+        let pre_dedup = members.len();
+        members.dedup();
+        if members.len() != pre_dedup {
+            return Err(GroupLockError::InvalidConfig(
+                "duplicate member ids".to_string(),
+            ));
+        }
+        if members.len() < 2 {
+            return Err(GroupLockError::InvalidConfig(
+                "a lock group requires at least 2 members".to_string(),
+            ));
+        }
+        if !members.contains(&local_id) {
+            return Err(GroupLockError::InvalidConfig(
+                "local_id is not in the member set".to_string(),
+            ));
+        }
+        if !members.contains(&initial_value_owner) {
+            return Err(GroupLockError::InvalidConfig(
+                "initial_value_owner is not in the member set".to_string(),
+            ));
+        }
+        for (name, d) in [
+            ("lease_duration", lease_duration),
+            ("renew_interval", renew_interval),
+            ("acquire_timeout", acquire_timeout),
+            ("round_timeout", round_timeout),
+            ("cas_backoff_base", cas_backoff_base),
+            ("waiter_poll_interval", waiter_poll_interval),
+        ] {
+            if d.is_zero() {
+                return Err(GroupLockError::InvalidConfig(format!(
+                    "{name} must be non-zero"
+                )));
+            }
+        }
+        if renew_interval * 2 >= lease_duration {
+            return Err(GroupLockError::InvalidConfig(
+                "renew_interval must be < lease_duration / 2".to_string(),
+            ));
+        }
+
+        let digest = Self::compute_digest(
+            &members,
+            initial_value_owner,
+            &[
+                lease_duration,
+                renew_interval,
+                steal_grace,
+                round_timeout,
+                waiter_poll_interval,
+            ],
+        );
+
+        Ok(Self {
+            members,
+            local_id,
+            initial_value_owner,
+            lease_duration,
+            renew_interval,
+            steal_grace,
+            acquire_timeout,
+            round_timeout,
+            cas_backoff_base,
+            waiter_poll_interval,
+            digest,
+        })
+    }
+
+    /// Digest over the fields that must agree across members. Locally-scoped knobs
+    /// (`local_id`, `acquire_timeout`, `cas_backoff_base`) are deliberately excluded.
+    fn compute_digest(members: &[MemberId], owner: MemberId, durations: &[Duration]) -> u64 {
+        let mut bytes = Vec::with_capacity(members.len() * 8 + durations.len() * 16 + 8);
+        for m in members {
+            bytes.extend_from_slice(&m.0.to_le_bytes());
+        }
+        bytes.extend_from_slice(&owner.0.to_le_bytes());
+        for d in durations {
+            bytes.extend_from_slice(&d.as_nanos().to_le_bytes());
+        }
+        fnv1a(&bytes)
+    }
+
+    pub fn members(&self) -> &[MemberId] {
+        &self.members
+    }
+
+    pub fn local_id(&self) -> MemberId {
+        self.local_id
+    }
+
+    pub fn initial_value_owner(&self) -> MemberId {
+        self.initial_value_owner
+    }
+
+    /// Majority threshold: `floor(n/2) + 1` of the configured membership.
+    pub fn majority(&self) -> usize {
+        self.members.len() / 2 + 1
+    }
+
+    pub fn lease_duration(&self) -> Duration {
+        self.lease_duration
+    }
+
+    pub fn renew_interval(&self) -> Duration {
+        self.renew_interval
+    }
+
+    pub fn steal_grace(&self) -> Duration {
+        self.steal_grace
+    }
+
+    pub fn acquire_timeout(&self) -> Duration {
+        self.acquire_timeout
+    }
+
+    pub fn round_timeout(&self) -> Duration {
+        self.round_timeout
+    }
+
+    pub fn cas_backoff_base(&self) -> Duration {
+        self.cas_backoff_base
+    }
+
+    pub fn waiter_poll_interval(&self) -> Duration {
+        self.waiter_poll_interval
+    }
+
+    pub fn digest(&self) -> u64 {
+        self.digest
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(members: Vec<u64>, local: u64, owner: u64) -> Result<GroupLockConfig, GroupLockError> {
+        GroupLockConfig::new(
+            members.into_iter().map(MemberId).collect(),
+            MemberId(local),
+            MemberId(owner),
+            Duration::from_millis(1000),
+            Duration::from_millis(200),
+            Duration::from_millis(300),
+            Duration::from_secs(10),
+            Duration::from_millis(500),
+            Duration::from_millis(50),
+            Duration::from_millis(250),
+        )
+    }
+
+    #[test]
+    fn validation() {
+        assert!(cfg(vec![1, 2, 3], 1, 2).is_ok());
+        assert!(cfg(vec![1], 1, 1).is_err());
+        assert!(cfg(vec![1, 1, 2], 1, 2).is_err());
+        assert!(cfg(vec![1, 2], 3, 1).is_err());
+        assert!(cfg(vec![1, 2], 1, 3).is_err());
+    }
+
+    #[test]
+    fn digest_ignores_local_knobs_but_not_membership() {
+        let a = cfg(vec![1, 2, 3], 1, 2).unwrap();
+        let b = cfg(vec![1, 2, 3], 3, 2).unwrap();
+        let c = cfg(vec![1, 2, 4], 1, 2).unwrap();
+        assert_eq!(a.digest(), b.digest());
+        assert_ne!(a.digest(), c.digest());
+    }
+
+    #[test]
+    fn majority_math() {
+        assert_eq!(cfg(vec![1, 2], 1, 1).unwrap().majority(), 2);
+        assert_eq!(cfg(vec![1, 2, 3], 1, 1).unwrap().majority(), 2);
+        assert_eq!(cfg(vec![1, 2, 3, 4], 1, 1).unwrap().majority(), 3);
+        assert_eq!(cfg(vec![1, 2, 3, 4, 5], 1, 1).unwrap().majority(), 3);
+    }
+}

--- a/netbeam/src/sync/group/create.rs
+++ b/netbeam/src/sync/group/create.rs
@@ -1,0 +1,95 @@
+//! Shared bootstrap for the typed facades: engine construction plus initial-value
+//! establishment. Exactly the `initial_value_owner` supplies `Some(initial)`
+//! (mirroring the 2-node primitives' one-`Some` rule, but with an explicit,
+//! config-designated owner instead of an implicit role).
+
+use crate::sync::group::acceptor::AcceptorStateStore;
+use crate::sync::group::config::GroupLockConfig;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::op_types::{Op, OpDenied};
+use crate::sync::group::proposer::ProposeError;
+use crate::sync::group::transport::GroupTransport;
+use crate::sync::group::LockId;
+use crate::sync::primitives::NetObject;
+use std::sync::Arc;
+
+pub(crate) async fn create_engine<T: NetObject>(
+    transport: Arc<GroupTransport>,
+    lock_id: LockId,
+    cfg: GroupLockConfig,
+    store: Arc<dyn AcceptorStateStore>,
+    initial: Option<T>,
+) -> Result<Arc<Engine>, GroupLockError> {
+    let is_owner = cfg.local_id() == cfg.initial_value_owner();
+    if is_owner != initial.is_some() {
+        return Err(GroupLockError::InitialValueOwnership {
+            local: cfg.local_id(),
+            owner: cfg.initial_value_owner(),
+        });
+    }
+    if transport.local_id() != cfg.local_id() {
+        return Err(GroupLockError::InvalidConfig(
+            "transport local_id differs from config local_id".to_string(),
+        ));
+    }
+
+    // Fold a value-type tag into the packet digest so two members configuring the
+    // same lock id with different T fail fast (dropped packets + loud logs) instead
+    // of exchanging garbage bytes. Uses type_name, which is stable within a build
+    // but not guaranteed across rustc versions — heterogeneous-toolchain deployments
+    // must keep member binaries in sync (already the norm for netbeam consumers).
+    let type_tag = crate::sync::group::fnv1a(core::any::type_name::<T>().as_bytes());
+    let mut digest_input = [0u8; 16];
+    digest_input[..8].copy_from_slice(&cfg.digest().to_le_bytes());
+    digest_input[8..].copy_from_slice(&type_tag.to_le_bytes());
+    let wire_digest = crate::sync::group::fnv1a(&digest_input);
+
+    let engine = Engine::new(transport, lock_id, cfg, wire_digest, store)?;
+    let result = establish(&engine, initial).await;
+    if result.is_err() {
+        engine.shutdown();
+    }
+    result.map(|_| engine)
+}
+
+async fn establish<T: NetObject>(
+    engine: &Arc<Engine>,
+    initial: Option<T>,
+) -> Result<(), GroupLockError> {
+    let deadline_ms =
+        crate::sync::group::engine_util::deadline(engine.now_ms(), engine.cfg.acquire_timeout());
+    match initial {
+        Some(value) => {
+            let op = Op::Init {
+                value: bincode::serialize(&value)?,
+            };
+            match engine.propose(&op, deadline_ms).await {
+                Ok(_) => Ok(()),
+                // a previous incarnation already initialized this lock: fine
+                Err(ProposeError::Denied(OpDenied::AlreadyInitialized, _)) => Ok(()),
+                Err(ProposeError::Denied(denied, _)) => Err(GroupLockError::Io(format!(
+                    "unexpected init denial: {denied:?}"
+                ))),
+                Err(ProposeError::QuorumUnavailable) => Err(GroupLockError::QuorumUnavailable),
+            }
+        }
+        None => loop {
+            match engine.quorum_read(deadline_ms).await {
+                Ok(Some(_)) => return Ok(()),
+                Ok(None) => {
+                    if engine.now_ms() >= deadline_ms {
+                        return Err(GroupLockError::Timeout);
+                    }
+                    citadel_io::time::sleep(engine.cfg.waiter_poll_interval()).await;
+                }
+                Err(ProposeError::QuorumUnavailable) => {
+                    return Err(GroupLockError::QuorumUnavailable)
+                }
+                Err(ProposeError::Denied(..)) => {
+                    unreachable!("quorum_read never yields op denials")
+                }
+            }
+        },
+    }
+}

--- a/netbeam/src/sync/group/engine.rs
+++ b/netbeam/src/sync/group/engine.rs
@@ -1,0 +1,224 @@
+//! Per-lock engine: owns the local voter (shared acceptor), the packet inbox task,
+//! request/response correlation, and the local monotonic clock epoch. The typed
+//! facades ([`crate::sync::group::mutex`], [`crate::sync::group::rwlock`]) wrap an
+//! `Arc<Engine>`; all protocol decisions are delegated to the pure core modules.
+
+use crate::sync::group::acceptor::{Acceptor, AcceptorStateStore};
+use crate::sync::group::admission;
+use crate::sync::group::config::GroupLockConfig;
+use crate::sync::group::engine_util::PendingRound;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::op_types::OpDenied;
+use crate::sync::group::record::LockRecord;
+use crate::sync::group::transport::GroupTransport;
+use crate::sync::group::wire::{Ballot, GroupMsg, GroupPacket};
+use crate::sync::group::{LockId, MemberId};
+use citadel_io::tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use citadel_io::tokio::sync::Notify;
+use citadel_io::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+/// Remote ballots may run ahead of ours, but a counter absurdly far ahead can only
+/// be a hostile attempt to exhaust the u64 space and wedge future proposals.
+const BALLOT_PLAUSIBILITY_WINDOW: u64 = 1 << 32;
+
+pub(crate) struct Engine {
+    pub(crate) cfg: GroupLockConfig,
+    /// Config digest folded with the value-type tag (see `create.rs`).
+    wire_digest: u64,
+    pub(crate) lock_id: LockId,
+    pub(crate) transport: Arc<GroupTransport>,
+    acceptor: Mutex<Acceptor>,
+    store: Arc<dyn AcceptorStateStore>,
+    pub(crate) pending: Mutex<HashMap<u64, UnboundedSender<(MemberId, GroupMsg)>>>,
+    req_ctr: AtomicU64,
+    /// Highest ballot counter observed anywhere; the next proposal exceeds it.
+    pub(crate) ballot_ctr: AtomicU64,
+    /// Woken by inbound `Nudge`s (a queue entry may have become admissible).
+    pub(crate) nudge: Notify,
+    epoch: Instant,
+    shutdown: Notify,
+}
+
+impl Engine {
+    pub(crate) fn new(
+        transport: Arc<GroupTransport>,
+        lock_id: LockId,
+        cfg: GroupLockConfig,
+        wire_digest: u64,
+        store: Arc<dyn AcceptorStateStore>,
+    ) -> Result<Arc<Self>, GroupLockError> {
+        let inbox = transport
+            .register_lock(lock_id, wire_digest)
+            .ok_or_else(|| {
+                GroupLockError::InvalidConfig(format!(
+                    "lock id {lock_id:?} already registered on this transport"
+                ))
+            })?;
+        let acceptor = store
+            .load(lock_id)
+            .map(Acceptor::from_persisted)
+            .unwrap_or_default();
+        let this = Arc::new(Self {
+            cfg,
+            wire_digest,
+            lock_id,
+            transport,
+            acceptor: Mutex::new(acceptor),
+            store,
+            pending: Mutex::new(HashMap::new()),
+            req_ctr: AtomicU64::new(0),
+            ballot_ctr: AtomicU64::new(0),
+            nudge: Notify::new(),
+            epoch: Instant::now(),
+            shutdown: Notify::new(),
+        });
+        let task = this.clone();
+        citadel_io::spawn(async move { task.inbox_loop(inbox).await });
+        Ok(this)
+    }
+
+    /// Milliseconds on the local monotonic clock since engine creation.
+    pub(crate) fn now_ms(&self) -> u64 {
+        self.epoch.elapsed().as_millis() as u64
+    }
+
+    pub(crate) fn next_req_id(&self) -> u64 {
+        self.req_ctr.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// RAII: the pending-map entry is removed on drop, so a cancelled proposer
+    /// future cannot leak its response channel.
+    pub(crate) fn register_pending(&self, req_id: u64) -> PendingRound<'_> {
+        let (tx, rx) = unbounded_channel();
+        let _ = self.pending.lock().insert(req_id, tx);
+        PendingRound {
+            engine: self,
+            req_id,
+            rx,
+        }
+    }
+
+    pub(crate) fn remote_members(&self) -> impl Iterator<Item = MemberId> + '_ {
+        let local = self.cfg.local_id();
+        self.cfg
+            .members()
+            .iter()
+            .copied()
+            .filter(move |m| *m != local)
+    }
+
+    pub(crate) fn packet(&self, req_id: u64, msg: GroupMsg) -> GroupPacket {
+        GroupPacket {
+            lock_id: self.lock_id,
+            from: self.cfg.local_id(),
+            req_id,
+            config_digest: self.wire_digest,
+            msg,
+        }
+    }
+
+    pub(crate) fn broadcast(&self, req_id: u64, msg: &GroupMsg) {
+        for member in self.remote_members() {
+            let pkt = self.packet(req_id, msg.clone());
+            self.transport.send_to(member, &pkt);
+        }
+    }
+
+    /// The local member's vote, identical in behavior to a remote voter.
+    /// Persists acceptor state before returning the reply (write-before-reply).
+    pub(crate) fn local_vote(&self, msg: &GroupMsg) -> Option<GroupMsg> {
+        let mut acc = self.acceptor.lock();
+        let reply = Self::vote(&mut acc, msg)?;
+        self.store.save(self.lock_id, acc.state());
+        Some(reply)
+    }
+
+    /// Track the highest ballot counter seen so future proposals exceed it.
+    /// Returns `false` (and does not advance) for implausibly large counters —
+    /// a hostile peer must not be able to exhaust the ballot space.
+    pub(crate) fn observe_ballot(&self, ballot: Ballot) -> bool {
+        let local = self.ballot_ctr.load(Ordering::Relaxed);
+        if ballot.counter > local.saturating_add(BALLOT_PLAUSIBILITY_WINDOW) {
+            log::warn!(target: "citadel", "[GroupLock] dropping implausible ballot {ballot:?} (local {local})");
+            return false;
+        }
+        self.ballot_ctr.fetch_max(ballot.counter, Ordering::Relaxed);
+        true
+    }
+
+    async fn inbox_loop(self: Arc<Self>, mut inbox: UnboundedReceiver<GroupPacket>) {
+        loop {
+            let packet = citadel_io::tokio::select! {
+                p = inbox.recv() => match p { Some(p) => p, None => break },
+                _ = self.shutdown.notified() => break,
+            };
+            match &packet.msg {
+                GroupMsg::Nudge => {
+                    self.nudge.notify_waiters();
+                }
+                msg if msg.is_voter_request() => {
+                    if !self.msg_sane(msg) {
+                        log::warn!(target: "citadel", "[GroupLock] dropping insane voter request from {:?}", packet.from);
+                        continue;
+                    }
+                    if let GroupMsg::Prepare { ballot } | GroupMsg::Accept { ballot, .. } = msg {
+                        if !self.observe_ballot(*ballot) {
+                            continue;
+                        }
+                    }
+                    if let Some(reply) = self.local_vote(msg) {
+                        let out = self.packet(packet.req_id, reply);
+                        self.transport.send_to(packet.from, &out);
+                    }
+                }
+                _ => {
+                    // response for a pending proposer round / hint gather
+                    if !self.msg_sane(&packet.msg) {
+                        log::warn!(target: "citadel", "[GroupLock] dropping insane response from {:?}", packet.from);
+                        continue;
+                    }
+                    if let GroupMsg::PrepareNack { promised, .. }
+                    | GroupMsg::AcceptNack { promised, .. } = &packet.msg
+                    {
+                        let _ = self.observe_ballot(*promised);
+                    }
+                    let tx = self.pending.lock().get(&packet.req_id).cloned();
+                    if let Some(tx) = tx {
+                        let _ = tx.send((packet.from, packet.msg));
+                    }
+                }
+            }
+        }
+        log::trace!(target: "citadel", "[GroupLock] engine inbox loop for {:?} ended", self.lock_id);
+    }
+
+    /// Nudges every member whose queue entry may have become admissible in `record`.
+    pub(crate) fn nudge_next(&self, record: &LockRecord) {
+        for member in admission::next_grants(record) {
+            if member == self.cfg.local_id() {
+                self.nudge.notify_waiters();
+            } else {
+                let pkt = self.packet(0, GroupMsg::Nudge);
+                self.transport.send_to(member, &pkt);
+            }
+        }
+    }
+
+    pub(crate) fn shutdown(&self) {
+        self.shutdown.notify_waiters();
+        self.transport.unregister_lock(self.lock_id);
+    }
+}
+
+/// Maps a denial that terminates an op to the public error space.
+pub(crate) fn denial_to_error(denied: OpDenied) -> GroupLockError {
+    match denied {
+        OpDenied::Uninitialized => GroupLockError::Uninitialized,
+        OpDenied::WouldBlock => GroupLockError::WouldBlock,
+        other => GroupLockError::Io(format!("unexpected op denial: {other:?}")),
+    }
+}

--- a/netbeam/src/sync/group/engine_util.rs
+++ b/netbeam/src/sync/group/engine_util.rs
@@ -1,0 +1,115 @@
+//! Engine support: saturating time math, the RAII pending-round handle, and the
+//! best-effort withdrawal helpers shared by acquire/guard error paths.
+
+use crate::sync::group::acceptor::Acceptor;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::op_types::Op;
+use crate::sync::group::wire::GroupMsg;
+use crate::sync::group::MemberId;
+use citadel_io::tokio::sync::mpsc::UnboundedReceiver;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Saturating `Duration -> millis-u64` (a `Duration::MAX` timeout must clamp,
+/// not panic in debug or truncate in release).
+pub(crate) fn ms(d: Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
+
+/// Saturating deadline arithmetic on the engine-local millisecond clock.
+pub(crate) fn deadline(anchor_ms: u64, d: Duration) -> u64 {
+    anchor_ms.saturating_add(ms(d))
+}
+
+/// RAII handle for one in-flight request's response channel (see
+/// [`Engine::register_pending`]).
+pub(crate) struct PendingRound<'a> {
+    pub(crate) engine: &'a Engine,
+    pub(crate) req_id: u64,
+    pub(crate) rx: UnboundedReceiver<(MemberId, GroupMsg)>,
+}
+
+impl Drop for PendingRound<'_> {
+    fn drop(&mut self) {
+        let _ = self.engine.pending.lock().remove(&self.req_id);
+    }
+}
+
+/// Convenience: ops carry the local identity so often that the engine offers it.
+impl Engine {
+    pub(crate) fn me(&self) -> MemberId {
+        self.cfg.local_id()
+    }
+
+    /// Withdraws a possibly-committed request/grant after an ambiguous failure.
+    /// `Op::Dequeue` is purpose-built for this: it removes the queue entry or (for
+    /// a grant whose critical section provably never ran) revokes it poison-free.
+    pub(crate) async fn best_effort_dequeue(&self, nonce: u64) {
+        let grace = deadline(self.now_ms(), self.cfg.round_timeout().saturating_mul(2));
+        match self.propose(&self.op_dequeue(nonce), grace).await {
+            Ok((rec, _)) => self.nudge_next(&rec),
+            Err(err) => {
+                log::trace!(target: "citadel", "[GroupLock] best-effort dequeue for nonce {nonce} unresolved: {err:?}")
+            }
+        }
+    }
+
+    pub(crate) fn spawn_best_effort_dequeue(self: Arc<Self>, nonce: u64) {
+        if citadel_io::tokio::runtime::Handle::try_current().is_ok() {
+            citadel_io::spawn(async move { self.best_effort_dequeue(nonce).await });
+        }
+    }
+
+    pub(crate) fn op_dequeue(&self, nonce: u64) -> Op {
+        Op::Dequeue {
+            member: self.me(),
+            nonce,
+        }
+    }
+}
+
+impl Engine {
+    /// Rejects wire messages whose embedded records/ballots fail sanity bounds.
+    pub(super) fn msg_sane(&self, msg: &GroupMsg) -> bool {
+        match msg {
+            GroupMsg::Accept { record, .. } => record.is_sane(),
+            GroupMsg::Promise {
+                accepted: Some((_, rec)),
+                ..
+            }
+            | GroupMsg::ReadHintRsp {
+                accepted: Some((_, rec)),
+            } => rec.is_sane(),
+            _ => true,
+        }
+    }
+
+    pub(super) fn vote(acc: &mut Acceptor, msg: &GroupMsg) -> Option<GroupMsg> {
+        use crate::sync::group::acceptor::{AcceptReply, PrepareReply};
+        match msg {
+            GroupMsg::Prepare { ballot } => Some(match acc.on_prepare(*ballot) {
+                PrepareReply::Promise { accepted } => GroupMsg::Promise {
+                    ballot: *ballot,
+                    accepted,
+                },
+                PrepareReply::Nack { promised } => GroupMsg::PrepareNack {
+                    ballot: *ballot,
+                    promised,
+                },
+            }),
+            GroupMsg::Accept { ballot, record } => {
+                Some(match acc.on_accept(*ballot, record.clone()) {
+                    AcceptReply::Accepted => GroupMsg::Accepted { ballot: *ballot },
+                    AcceptReply::Nack { promised } => GroupMsg::AcceptNack {
+                        ballot: *ballot,
+                        promised,
+                    },
+                })
+            }
+            GroupMsg::ReadHint => Some(GroupMsg::ReadHintRsp {
+                accepted: acc.read_hint(),
+            }),
+            _ => None,
+        }
+    }
+}

--- a/netbeam/src/sync/group/error.rs
+++ b/netbeam/src/sync/group/error.rs
@@ -1,0 +1,68 @@
+//! Error type for the n-node group lock primitives.
+
+use crate::sync::group::{Fence, MemberId};
+
+#[derive(Debug)]
+pub enum GroupLockError {
+    /// The acquire deadline elapsed before the lock could be granted.
+    Timeout,
+    /// A majority of the configured members could not be reached within the
+    /// operation's deadline. The op may or may not have partially propagated;
+    /// all ops are idempotent under retry via their (member, nonce) identity.
+    QuorumUnavailable,
+    /// The local grant was revoked: another member observed this holder as
+    /// stagnant and stole the entry (or the lease expired locally first).
+    Stolen {
+        /// The fence of the grant that was lost.
+        fence: Fence,
+    },
+    /// `try_lock`/`try_read`/`try_write` would have blocked.
+    WouldBlock,
+    /// The lock record has not been initialized by `initial_value_owner` yet.
+    Uninitialized,
+    /// A configuration precondition failed (bad durations, duplicate members,
+    /// local/owner not in the member set, n < 2, ...).
+    InvalidConfig(String),
+    /// `create()` was called with `Some(initial)` on a non-owner member, or
+    /// `None` on the owner.
+    InitialValueOwnership {
+        local: MemberId,
+        owner: MemberId,
+    },
+    /// The engine for this lock was shut down (its `NetGroup*` handle dropped).
+    Shutdown,
+    Serialization(String),
+    Io(String),
+}
+
+impl core::fmt::Display for GroupLockError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "group lock acquire timed out"),
+            Self::QuorumUnavailable => {
+                write!(f, "a majority of group members is unreachable")
+            }
+            Self::Stolen { fence } => {
+                write!(f, "grant with fence {} was revoked/stolen", fence.0)
+            }
+            Self::WouldBlock => write!(f, "lock is contended (try_* would block)"),
+            Self::Uninitialized => write!(f, "lock record not initialized by owner yet"),
+            Self::InvalidConfig(msg) => write!(f, "invalid group lock config: {msg}"),
+            Self::InitialValueOwnership { local, owner } => write!(
+                f,
+                "initial value must be supplied by owner {owner:?} exactly (local: {local:?})"
+            ),
+            Self::Shutdown => write!(f, "group lock engine was shut down"),
+            Self::Serialization(msg) => write!(f, "serialization failure: {msg}"),
+            Self::Io(msg) => write!(f, "group transport i/o failure: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for GroupLockError {}
+
+impl From<bincode::Error> for GroupLockError {
+    fn from(err: bincode::Error) -> Self {
+        Self::Serialization(err.to_string())
+    }
+}

--- a/netbeam/src/sync/group/fault_tests.rs
+++ b/netbeam/src/sync/group/fault_tests.rs
@@ -1,0 +1,201 @@
+//! Layer-4 fault-injection tests: crashed holders (recovered flag + bounded
+//! handoff), partitions (minority stalls + self-invalidates, majority steals,
+//! stale release fenced after heal), and quorum-loss behavior at n = 2.
+
+use crate::sync::group::acceptor::EphemeralAcceptorStore;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::integration_tests::{create_mutexes, members};
+use crate::sync::group::test_mesh::TestMesh;
+use crate::sync::group::{LockId, NetGroupMutex};
+use citadel_io::tokio;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// An isolated holder cannot renew: its entry stagnates, a waiter steals, and the
+/// next write grant reports `recovered` with the crashed member's identity — while
+/// the crashed holder's uncommitted mutation stays invisible.
+#[tokio::test(flavor = "multi_thread")]
+async fn killed_holder_is_stolen_with_recovery_flag() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let mesh = TestMesh::new(&all);
+    let mutexes = create_mutexes::<u64>(&mesh, &all, LockId::from_name("crash"), 100).await;
+
+    let mut dying_guard = mutexes[0].lock().await.unwrap();
+    *dying_guard = 666; // uncommitted mutation: must never become visible
+    let dying_fence = dying_guard.fence();
+    mesh.isolate(all[0]); // "crash" the holder mid-critical-section
+
+    let start = std::time::Instant::now();
+    let guard = mutexes[1].lock().await.unwrap();
+    // bounded handoff: lease + grace + rounds, with slack for test scheduling
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "steal took too long: {:?}",
+        start.elapsed()
+    );
+    let recovered = guard.recovered().expect("must report writer crash");
+    assert_eq!(recovered.member, all[0]);
+    assert_eq!(recovered.fence, dying_fence);
+    assert_eq!(*guard, 100, "uncommitted mutation must be invisible");
+    assert!(guard.fence() > dying_fence, "fences stay monotonic");
+
+    // the isolated holder learns it lost the grant
+    dying_guard.invalidated().await;
+    assert!(!dying_guard.is_valid());
+    assert!(matches!(
+        dying_guard.release().await,
+        Err(GroupLockError::Stolen { .. }) | Err(GroupLockError::QuorumUnavailable)
+    ));
+}
+
+/// Partition a 5-mesh 2/3: the majority side steals and proceeds; after healing,
+/// the stale holder's explicit release is fenced out with `Stolen`.
+#[tokio::test(flavor = "multi_thread")]
+async fn partition_majority_steals_minority_fenced_after_heal() {
+    citadel_logging::setup_log();
+    let all = members(5);
+    let mesh = TestMesh::new(&all);
+    let mutexes = create_mutexes::<u64>(&mesh, &all, LockId::from_name("split"), 1).await;
+
+    let mut stale_guard = mutexes[0].lock().await.unwrap();
+    *stale_guard = 2; // will never commit
+                      // {1,2} vs {3,4,5}
+    mesh.partition(&all[..2], &all[2..]);
+
+    // majority side acquires (steals the stagnant holder)
+    let guard = mutexes[3].lock().await.unwrap();
+    assert!(guard.recovered().is_some());
+    assert_eq!(*guard, 1, "minority mutation must not be visible");
+    guard.release().await.unwrap();
+
+    // minority holder self-invalidates (cannot renew against a majority)
+    stale_guard.invalidated().await;
+    assert!(!stale_guard.is_valid());
+
+    mesh.heal_all();
+    // stale release after heal must be fenced, and must NOT overwrite the value
+    assert!(matches!(
+        stale_guard.release().await,
+        Err(GroupLockError::Stolen { .. })
+    ));
+    let check = mutexes[4].lock().await.unwrap();
+    assert_eq!(*check, 1);
+}
+
+/// With f = 2 of n = 5 voters isolated, the group stays fully live.
+#[tokio::test(flavor = "multi_thread")]
+async fn survives_f_minority_voter_crashes_n5() {
+    citadel_logging::setup_log();
+    let all = members(5);
+    let mesh = TestMesh::new(&all);
+    let mutexes = create_mutexes::<u64>(&mesh, &all, LockId::from_name("f2"), 0).await;
+
+    mesh.isolate(all[3]);
+    mesh.isolate(all[4]);
+
+    for round in 0..3u64 {
+        let mut guard = mutexes[(round % 3) as usize].lock().await.unwrap();
+        *guard += 1;
+        guard.release().await.unwrap();
+    }
+    let guard = mutexes[0].lock().await.unwrap();
+    assert_eq!(*guard, 3);
+}
+
+/// n = 2 has majority 2: losing the peer makes acquisition fail (bounded), never
+/// silently succeed — the documented degenerate case.
+#[tokio::test(flavor = "multi_thread")]
+async fn n2_quorum_loss_fails_bounded() {
+    citadel_logging::setup_log();
+    let all = members(2);
+    let mesh = TestMesh::new(&all);
+    // shorter acquire timeout to keep the test fast
+    let futures = all.iter().map(|m| {
+        let mut cfg_all = all.clone();
+        cfg_all.sort_unstable();
+        let cfg = crate::sync::group::GroupLockConfig::new(
+            cfg_all,
+            *m,
+            all[0],
+            Duration::from_millis(600),
+            Duration::from_millis(150),
+            Duration::from_millis(250),
+            Duration::from_secs(2),
+            Duration::from_millis(300),
+            Duration::from_millis(25),
+            Duration::from_millis(75),
+        )
+        .unwrap();
+        let init = (*m == all[0]).then_some(5u64);
+        NetGroupMutex::<u64>::create(
+            mesh.transport(*m),
+            LockId::from_name("n2"),
+            cfg,
+            Arc::new(EphemeralAcceptorStore::default()),
+            init,
+        )
+    });
+    let mutexes: Vec<_> = futures::future::join_all(futures)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    mesh.isolate(all[1]);
+    let start = std::time::Instant::now();
+    let result = mutexes[0].lock().await;
+    assert!(
+        matches!(
+            result,
+            Err(GroupLockError::QuorumUnavailable) | Err(GroupLockError::Timeout)
+        ),
+        "acquire must fail without a majority, got ok={}",
+        result.is_ok()
+    );
+    assert!(start.elapsed() < Duration::from_secs(10));
+
+    // heal: the group works again
+    mesh.rejoin(all[1]);
+    let mut guard = mutexes[1].lock().await.unwrap();
+    *guard += 1;
+    guard.release().await.unwrap();
+    let guard = mutexes[0].lock().await.unwrap();
+    assert_eq!(*guard, 6);
+}
+
+/// A waiter that dies in the queue is evicted by whoever it blocks; the queue
+/// does not wedge behind a ghost entry.
+#[tokio::test(flavor = "multi_thread")]
+async fn dead_waiter_is_evicted() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let mesh = TestMesh::new(&all);
+    let mut mutexes = create_mutexes::<u64>(&mesh, &all, LockId::from_name("ghost"), 0).await;
+
+    let guard = mutexes[0].lock().await.unwrap();
+
+    // member 2 queues, then "crashes" while waiting
+    let m1 = mutexes.remove(1);
+    let waiter = tokio::spawn(async move {
+        let _ = m1.lock().await; // never granted: isolated below
+        m1
+    });
+    citadel_io::time::sleep(Duration::from_millis(300)).await; // let it enqueue
+    mesh.isolate(all[1]);
+
+    guard.release().await.unwrap();
+
+    // member 3 queued behind the ghost must still make progress (janitor evicts it)
+    let start = std::time::Instant::now();
+    let mut g = mutexes[1].lock().await.unwrap(); // mutexes[1] is member 3 now
+    assert!(
+        start.elapsed() < Duration::from_secs(10),
+        "eviction took too long: {:?}",
+        start.elapsed()
+    );
+    assert!(g.recovered().is_none(), "a stolen WAITER must not poison");
+    *g += 1;
+    g.release().await.unwrap();
+    waiter.abort();
+}

--- a/netbeam/src/sync/group/grant_state.rs
+++ b/netbeam/src/sync/group/grant_state.rs
@@ -1,0 +1,239 @@
+//! Shared per-grant state: lease bookkeeping, the renew (heartbeat) task, and the
+//! release/downgrade CAS flows used by every guard type.
+
+use crate::sync::group::acquire::Grant;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::engine_util::deadline;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::op_types::{Op, OpDenied, OpOutcome};
+use crate::sync::group::proposer::ProposeError;
+use crate::sync::group::Fence;
+use citadel_io::tokio::sync::watch;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+pub(crate) struct GrantState {
+    pub(crate) engine: Arc<Engine>,
+    pub(crate) nonce: u64,
+    pub(crate) fence: Fence,
+    lease_seq: AtomicU64,
+    valid_until_ms: AtomicU64,
+    invalid_tx: watch::Sender<bool>,
+    released: AtomicBool,
+}
+
+impl GrantState {
+    pub(crate) fn new(engine: Arc<Engine>, grant: &Grant) -> Arc<Self> {
+        let (invalid_tx, _) = watch::channel(false);
+        let state = Arc::new(Self {
+            engine,
+            nonce: grant.nonce,
+            fence: grant.fence,
+            lease_seq: AtomicU64::new(0),
+            valid_until_ms: AtomicU64::new(grant.valid_until_ms),
+            invalid_tx,
+            released: AtomicBool::new(false),
+        });
+        let renewer = state.clone();
+        citadel_io::spawn(async move { renewer.renew_loop().await });
+        state
+    }
+
+    pub(crate) fn is_valid(&self) -> bool {
+        !*self.invalid_tx.borrow()
+            && self.engine.now_ms() < self.valid_until_ms.load(Ordering::Acquire)
+    }
+
+    pub(crate) async fn invalidated(&self) {
+        let mut rx = self.invalid_tx.subscribe();
+        while !*rx.borrow_and_update() {
+            if rx.changed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    fn mark_invalid(&self) {
+        log::trace!(target: "citadel", "[GroupLock] {:?} grant fence={:?} marked invalid", self.engine.me(), self.fence);
+        // send_replace, not send: `send` is a no-op when no receiver is subscribed
+        // yet, which would leave is_valid()/invalidated() permanently stale
+        let _ = self.invalid_tx.send_replace(true);
+    }
+
+    /// Holder heartbeat. Validity is re-anchored at each renew round's START, so the
+    /// holder's view expires strictly before any observer's steal window (which opens
+    /// only after `lease_duration + steal_grace` of observed stagnation).
+    async fn renew_loop(self: Arc<Self>) {
+        let interval = self.engine.cfg.renew_interval();
+        loop {
+            citadel_io::time::sleep(interval).await;
+            if self.released.load(Ordering::Acquire) {
+                return;
+            }
+            let anchor_ms = self.engine.now_ms();
+            let deadline_ms = self.valid_until_ms.load(Ordering::Acquire);
+            let op = Op::Renew {
+                member: self.engine.me(),
+                nonce: self.nonce,
+                expect_fence: self.fence,
+                expect_lease_seq: self.lease_seq.load(Ordering::Acquire),
+            };
+            match self.engine.propose(&op, deadline_ms).await {
+                Ok((_, OpOutcome::Renewed { lease_seq })) => {
+                    self.lease_seq.store(lease_seq, Ordering::Release);
+                    let new_deadline = deadline(anchor_ms, self.engine.cfg.lease_duration());
+                    self.valid_until_ms.store(new_deadline, Ordering::Release);
+                }
+                Ok((_, other)) => {
+                    log::warn!(target: "citadel", "[GroupLock] unexpected renew outcome: {other:?}");
+                }
+                Err(ProposeError::Denied(_, _)) => {
+                    // fence/seq moved on: we were stolen
+                    self.mark_invalid();
+                    return;
+                }
+                Err(ProposeError::QuorumUnavailable) => {
+                    if self.engine.now_ms() >= self.valid_until_ms.load(Ordering::Acquire) {
+                        // could not renew within our own validity: self-invalidate
+                        self.mark_invalid();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Removes the grant. `new_value` = serialized T when the guard mutated it.
+    ///
+    /// Always attempts the Release CAS, even after local self-invalidation: the CAS
+    /// is fence-guarded, so if the entry was never actually stolen (e.g. a partition
+    /// healed before anyone's steal window elapsed) this both cleans up promptly and
+    /// legitimately publishes the value — mutual exclusion held the entire time.
+    /// A genuinely stolen grant is denied and surfaced as `Stolen`.
+    pub(crate) async fn release(&self, new_value: Option<Vec<u8>>) -> Result<(), GroupLockError> {
+        if self.released.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+        let deadline_ms = deadline(self.engine.now_ms(), self.engine.cfg.acquire_timeout());
+        let op = Op::Release {
+            member: self.engine.me(),
+            nonce: self.nonce,
+            expect_fence: self.fence,
+            new_value,
+        };
+        match self.engine.propose(&op, deadline_ms).await {
+            Ok((rec, _)) => {
+                self.engine.nudge_next(&rec);
+                Ok(())
+            }
+            Err(ProposeError::Denied(OpDenied::NotHolder, rec)) => {
+                self.mark_invalid();
+                if let Some(rec) = &rec {
+                    self.engine.nudge_next(rec);
+                }
+                Err(GroupLockError::Stolen { fence: self.fence })
+            }
+            Err(ProposeError::Denied(denied, _)) => Err(super::engine::denial_to_error(denied)),
+            Err(ProposeError::QuorumUnavailable) => {
+                // ambiguous: keep retrying in the background until the CAS commits,
+                // is denied (stolen), or the steal window has certainly elapsed —
+                // without this, a transient quorum loss abandons a live grant
+                self.spawn_release_retry(op);
+                Err(GroupLockError::QuorumUnavailable)
+            }
+        }
+    }
+
+    /// Detached bounded retry for an ambiguous release. Fence-guarded, so replays
+    /// are idempotent (`last_released` tombstone) and steals deny it.
+    fn spawn_release_retry(&self, op: Op) {
+        let engine = self.engine.clone();
+        let retry_window = self
+            .engine
+            .cfg
+            .lease_duration()
+            .saturating_add(self.engine.cfg.steal_grace())
+            .saturating_mul(2);
+        if citadel_io::tokio::runtime::Handle::try_current().is_ok() {
+            citadel_io::spawn(async move {
+                let deadline_ms = deadline(engine.now_ms(), retry_window);
+                match engine.propose(&op, deadline_ms).await {
+                    Ok((rec, _)) => engine.nudge_next(&rec),
+                    Err(err) => {
+                        log::trace!(target: "citadel", "[GroupLock] background release retry ended: {err:?}")
+                    }
+                }
+            });
+        }
+    }
+
+    /// Atomically converts this write grant into a read grant with a fresh fence.
+    pub(crate) async fn downgrade(
+        &self,
+        new_value: Option<Vec<u8>>,
+    ) -> Result<Grant, GroupLockError> {
+        if self.released.swap(true, Ordering::AcqRel) {
+            return Err(GroupLockError::Io("grant already released".to_string()));
+        }
+        if *self.invalid_tx.borrow() {
+            return Err(GroupLockError::Stolen { fence: self.fence });
+        }
+        let anchor_ms = self.engine.now_ms();
+        let deadline_ms = deadline(anchor_ms, self.engine.cfg.acquire_timeout());
+        let op = Op::Downgrade {
+            member: self.engine.me(),
+            nonce: self.nonce,
+            expect_fence: self.fence,
+            new_value,
+        };
+        match self.engine.propose(&op, deadline_ms).await {
+            Ok((rec, OpOutcome::Downgraded { fence })) => {
+                // newly-admissible readers may now claim alongside us
+                self.engine.nudge_next(&rec);
+                Ok(Grant {
+                    nonce: self.nonce,
+                    fence,
+                    recovered: None,
+                    value: rec.value.clone(),
+                    value_version: rec.value_version,
+                    valid_until_ms: deadline(anchor_ms, self.engine.cfg.lease_duration()),
+                })
+            }
+            Ok((_, other)) => Err(GroupLockError::Io(format!(
+                "unexpected downgrade outcome: {other:?}"
+            ))),
+            Err(ProposeError::Denied(OpDenied::NotHolder, _)) => {
+                self.mark_invalid();
+                Err(GroupLockError::Stolen { fence: self.fence })
+            }
+            Err(ProposeError::Denied(denied, _)) => Err(super::engine::denial_to_error(denied)),
+            Err(ProposeError::QuorumUnavailable) => {
+                // the downgrade may or may not have committed; Dequeue removes
+                // whichever entry (writer or downgraded reader) exists, poison-free
+                self.engine.clone().spawn_best_effort_dequeue(self.nonce);
+                Err(GroupLockError::QuorumUnavailable)
+            }
+        }
+    }
+
+    /// Best-effort release used from guard `Drop` (existing netbeam idiom).
+    pub(crate) fn spawn_release(self: Arc<Self>, new_value: Option<Vec<u8>>) {
+        if self.released.load(Ordering::Acquire) {
+            return; // explicit release/downgrade already consumed the grant
+        }
+        if citadel_io::tokio::runtime::Handle::try_current().is_ok() {
+            citadel_io::spawn(async move {
+                if let Err(err) = self.release(new_value).await {
+                    log::warn!(target: "citadel", "[GroupLock] drop-release failed: {err}");
+                }
+            });
+        } else {
+            // no runtime: the wire release cannot run, but the renew task (if its
+            // runtime still lives) must stop heartbeating or the lease renews
+            // forever and peers can never steal the abandoned grant
+            self.released.store(true, Ordering::Release);
+            self.mark_invalid();
+            log::warn!(target: "citadel", "[GroupLock] no runtime for drop-release; peers will steal after the lease window");
+        }
+    }
+}

--- a/netbeam/src/sync/group/guard.rs
+++ b/netbeam/src/sync/group/guard.rs
@@ -1,0 +1,186 @@
+//! Guard types shared by [`crate::sync::group::mutex`] and
+//! [`crate::sync::group::rwlock`].
+//!
+//! A guard cannot physically revoke `&mut T` after its lease is lost: local code may
+//! keep using its in-memory copy, but netbeam-managed state stays safe (a stale
+//! holder's release CAS is fenced out). For EXTERNAL side effects, callers must check
+//! [`NetGroupWriteGuard::is_valid`]/[`NetGroupWriteGuard::fence`] and pass the fence
+//! to downstream systems.
+
+use crate::sync::group::acquire::Grant;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::grant_state::GrantState;
+use crate::sync::group::record::PoisonInfo;
+use crate::sync::group::Fence;
+use crate::sync::primitives::NetObject;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+/// Exclusive guard. Mutating access (`DerefMut`) marks the value dirty; only dirty
+/// values are shipped on release.
+pub struct NetGroupWriteGuard<T: NetObject> {
+    pub(crate) value: Option<T>,
+    pub(crate) mutated: bool,
+    pub(crate) recovered: Option<PoisonInfo>,
+    pub(crate) value_version: Fence,
+    pub(crate) state: Arc<GrantState>,
+}
+
+/// Shared guard (read-only view of the value).
+pub struct NetGroupReadGuard<T: NetObject> {
+    pub(crate) value: T,
+    pub(crate) value_version: Fence,
+    pub(crate) state: Arc<GrantState>,
+}
+
+impl<T: NetObject> NetGroupWriteGuard<T> {
+    pub(crate) fn from_grant(engine: Arc<Engine>, grant: Grant) -> Result<Self, GroupLockError> {
+        let value = match bincode::deserialize::<T>(&grant.value) {
+            Ok(v) => v,
+            Err(err) => {
+                // the grant IS committed: withdraw it (poison-free — the critical
+                // section provably never ran) instead of orphaning it
+                engine.spawn_best_effort_dequeue(grant.nonce);
+                return Err(err.into());
+            }
+        };
+        Ok(Self {
+            value: Some(value),
+            mutated: false,
+            recovered: grant.recovered.clone(),
+            value_version: grant.value_version,
+            state: GrantState::new(engine, &grant),
+        })
+    }
+
+    /// The fencing token of this grant — pass it to external systems so they can
+    /// reject operations from stale holders.
+    pub fn fence(&self) -> Fence {
+        self.state.fence
+    }
+
+    /// Version (fence) of the value snapshot this guard started from.
+    pub fn value_version(&self) -> Fence {
+        self.value_version
+    }
+
+    /// `false` once the lease lapsed locally or the grant was observed stolen.
+    pub fn is_valid(&self) -> bool {
+        self.state.is_valid()
+    }
+
+    /// Resolves when the grant is invalidated (stolen or lease lost). Useful to
+    /// abort long critical sections early.
+    pub async fn invalidated(&self) {
+        self.state.invalidated().await
+    }
+
+    /// `Some` iff the previous writer crashed mid-critical-section and this grant
+    /// recovered the lock ("poisoned" semantics): the value is the last COMMITTED
+    /// snapshot; the crashed holder's uncommitted mutations were discarded.
+    pub fn recovered(&self) -> Option<&PoisonInfo> {
+        self.recovered.as_ref()
+    }
+
+    /// Releases explicitly, surfacing errors the `Drop` path can only log.
+    pub async fn release(mut self) -> Result<(), GroupLockError> {
+        let new_value = self.take_release_payload()?;
+        self.state.release(new_value).await
+    }
+
+    /// Converts a write guard into a read guard atomically (fresh fence; publishes
+    /// the value if mutated). No `upgrade` exists: two readers upgrading deadlock.
+    pub async fn downgrade(mut self) -> Result<NetGroupReadGuard<T>, GroupLockError> {
+        let new_value = self.take_release_payload()?;
+        let grant = self.state.downgrade(new_value).await?;
+        NetGroupReadGuard::from_grant(self.state.engine.clone(), grant)
+    }
+
+    fn take_release_payload(&mut self) -> Result<Option<Vec<u8>>, GroupLockError> {
+        let value = self.value.take();
+        if !self.mutated {
+            return Ok(None);
+        }
+        self.mutated = false; // the Drop that follows an explicit release is a no-op
+        let value = value
+            .ok_or_else(|| GroupLockError::Io("write guard value already taken".to_string()))?;
+        Ok(Some(bincode::serialize(&value)?))
+    }
+}
+
+impl<T: NetObject> NetGroupReadGuard<T> {
+    pub(crate) fn from_grant(engine: Arc<Engine>, grant: Grant) -> Result<Self, GroupLockError> {
+        let value = match bincode::deserialize::<T>(&grant.value) {
+            Ok(v) => v,
+            Err(err) => {
+                engine.spawn_best_effort_dequeue(grant.nonce);
+                return Err(err.into());
+            }
+        };
+        Ok(Self {
+            value,
+            value_version: grant.value_version,
+            state: GrantState::new(engine, &grant),
+        })
+    }
+
+    pub fn fence(&self) -> Fence {
+        self.state.fence
+    }
+
+    pub fn value_version(&self) -> Fence {
+        self.value_version
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.state.is_valid()
+    }
+
+    pub async fn invalidated(&self) {
+        self.state.invalidated().await
+    }
+
+    pub async fn release(self) -> Result<(), GroupLockError> {
+        self.state.release(None).await
+    }
+}
+
+impl<T: NetObject> Deref for NetGroupWriteGuard<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.value.as_ref().expect("value present until release")
+    }
+}
+
+impl<T: NetObject> DerefMut for NetGroupWriteGuard<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.mutated = true;
+        self.value.as_mut().expect("value present until release")
+    }
+}
+
+impl<T: NetObject> Deref for NetGroupReadGuard<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+impl<T: NetObject> Drop for NetGroupWriteGuard<T> {
+    fn drop(&mut self) {
+        match self.take_release_payload() {
+            Ok(payload) => self.state.clone().spawn_release(payload),
+            Err(err) => {
+                log::warn!(target: "citadel", "[GroupLock] failed to serialize value on drop; releasing without it: {err}");
+                self.state.clone().spawn_release(None);
+            }
+        }
+    }
+}
+
+impl<T: NetObject> Drop for NetGroupReadGuard<T> {
+    fn drop(&mut self) {
+        self.state.clone().spawn_release(None);
+    }
+}

--- a/netbeam/src/sync/group/integration_tests.rs
+++ b/netbeam/src/sync/group/integration_tests.rs
@@ -1,0 +1,233 @@
+//! Layer-3 integration tests: full stack over the in-memory mesh (n = 3 and 5),
+//! exercising contention, value propagation, reader batching, writer priority,
+//! downgrade, and try_* semantics.
+
+use crate::sync::group::acceptor::EphemeralAcceptorStore;
+use crate::sync::group::test_mesh::TestMesh;
+use crate::sync::group::{GroupLockConfig, LockId, MemberId, NetGroupMutex, NetGroupRwLock};
+use citadel_io::tokio;
+use futures::future::join_all;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+pub(crate) fn members(n: u64) -> Vec<MemberId> {
+    (1..=n).map(MemberId).collect()
+}
+
+pub(crate) fn test_config(all: &[MemberId], local: MemberId) -> GroupLockConfig {
+    GroupLockConfig::new(
+        all.to_vec(),
+        local,
+        all[0],                     // lowest member id owns the initial value
+        Duration::from_millis(600), // lease_duration
+        Duration::from_millis(150), // renew_interval
+        Duration::from_millis(250), // steal_grace
+        Duration::from_secs(15),    // acquire_timeout
+        Duration::from_millis(400), // round_timeout
+        Duration::from_millis(25),  // cas_backoff_base
+        Duration::from_millis(75),  // waiter_poll_interval
+    )
+    .unwrap()
+}
+
+pub(crate) async fn create_mutexes<T: crate::sync::primitives::NetObject>(
+    mesh: &TestMesh,
+    all: &[MemberId],
+    lock: LockId,
+    initial: T,
+) -> Vec<NetGroupMutex<T>> {
+    let futures = all.iter().map(|m| {
+        let cfg = test_config(all, *m);
+        let init = (*m == all[0]).then(|| initial.clone());
+        NetGroupMutex::<T>::create(
+            mesh.transport(*m),
+            lock,
+            cfg,
+            Arc::new(EphemeralAcceptorStore::default()),
+            init,
+        )
+    });
+    join_all(futures)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+pub(crate) async fn create_rwlocks<T: crate::sync::primitives::NetObject>(
+    mesh: &TestMesh,
+    all: &[MemberId],
+    lock: LockId,
+    initial: T,
+) -> Vec<NetGroupRwLock<T>> {
+    let futures = all.iter().map(|m| {
+        let cfg = test_config(all, *m);
+        let init = (*m == all[0]).then(|| initial.clone());
+        NetGroupRwLock::<T>::create(
+            mesh.transport(*m),
+            lock,
+            cfg,
+            Arc::new(EphemeralAcceptorStore::default()),
+            init,
+        )
+    });
+    join_all(futures)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mutex_contended_counter_n3() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let mesh = TestMesh::new(&all);
+    let mutexes = create_mutexes::<u64>(&mesh, &all, LockId::from_name("counter"), 0).await;
+
+    const PER_MEMBER: u64 = 20;
+    let in_cs = Arc::new(AtomicBool::new(false));
+    let max_fence_seen = Arc::new(AtomicU64::new(0));
+
+    let tasks = mutexes.into_iter().map(|mutex| {
+        let in_cs = in_cs.clone();
+        let max_fence_seen = max_fence_seen.clone();
+        tokio::spawn(async move {
+            for _ in 0..PER_MEMBER {
+                let mut guard = mutex.lock().await.unwrap();
+                // mutual exclusion: nobody else is in the critical section
+                assert!(!in_cs.swap(true, Ordering::SeqCst), "two holders at once!");
+                assert!(guard.recovered().is_none());
+                // fences strictly increase across grants
+                let prev = max_fence_seen.swap(guard.fence().0, Ordering::SeqCst);
+                assert!(guard.fence().0 > prev, "fence went backwards");
+                *guard += 1;
+                assert!(in_cs.swap(false, Ordering::SeqCst), "cs flag desynced");
+                guard.release().await.unwrap();
+            }
+            mutex
+        })
+    });
+    let mutexes: Vec<_> = join_all(tasks)
+        .await
+        .into_iter()
+        .map(|r| r.unwrap())
+        .collect();
+
+    let final_guard = mutexes[0].lock().await.unwrap();
+    assert_eq!(*final_guard, 3 * PER_MEMBER);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mutex_drop_propagates_value_n5() {
+    citadel_logging::setup_log();
+    let all = members(5);
+    let mesh = TestMesh::new(&all);
+    let mutexes =
+        create_mutexes::<Vec<u32>>(&mesh, &all, LockId::from_name("payload"), vec![]).await;
+
+    {
+        let mut guard = mutexes[2].lock().await.unwrap();
+        guard.push(1234);
+        // drop (not explicit release) must still propagate the mutated value
+    }
+    // another member observes the committed value
+    let guard = mutexes[4].lock().await.unwrap();
+    assert_eq!(&*guard, &vec![1234]);
+    assert!(guard.value_version().0 > 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rwlock_readers_batch_and_writers_have_priority_n3() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let mesh = TestMesh::new(&all);
+    let rwlocks = create_rwlocks::<u64>(&mesh, &all, LockId::from_name("rw"), 7).await;
+
+    // all three members hold read locks CONCURRENTLY
+    let concurrent = Arc::new(AtomicU64::new(0));
+    let peak = Arc::new(AtomicU64::new(0));
+    let tasks = rwlocks.iter().map(|rw| {
+        let concurrent = concurrent.clone();
+        let peak = peak.clone();
+        async move {
+            let guard = rw.read().await.unwrap();
+            assert_eq!(*guard, 7);
+            let now = concurrent.fetch_add(1, Ordering::SeqCst) + 1;
+            peak.fetch_max(now, Ordering::SeqCst);
+            citadel_io::time::sleep(Duration::from_millis(300)).await;
+            concurrent.fetch_sub(1, Ordering::SeqCst);
+            guard.release().await.unwrap();
+        }
+    });
+    join_all(tasks).await;
+    assert_eq!(
+        peak.load(Ordering::SeqCst),
+        3,
+        "readers must overlap (batching)"
+    );
+
+    // writer excludes readers; a write commits and is visible everywhere
+    let mut w = rwlocks[1].write().await.unwrap();
+    *w = 99;
+    w.release().await.unwrap();
+    let r = rwlocks[2].read().await.unwrap();
+    assert_eq!(*r, 99);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rwlock_downgrade_lets_readers_join() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let mesh = TestMesh::new(&all);
+    let rwlocks = create_rwlocks::<u64>(&mesh, &all, LockId::from_name("dg"), 0).await;
+
+    let mut w = rwlocks[0].write().await.unwrap();
+    *w = 5;
+    let r0 = w.downgrade().await.unwrap();
+    assert_eq!(*r0, 5, "downgraded guard sees its own write");
+
+    // another member's reader joins while the downgraded read guard is held
+    let r1 = rwlocks[1].read().await.unwrap();
+    assert_eq!(*r1, 5);
+    drop(r1);
+    drop(r0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn try_lock_semantics() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let mesh = TestMesh::new(&all);
+    let mutexes = create_mutexes::<u64>(&mesh, &all, LockId::from_name("try"), 0).await;
+
+    let guard = mutexes[0].lock().await.unwrap();
+    assert!(
+        mutexes[1].try_lock().await.unwrap().is_none(),
+        "try_lock must not block or enqueue"
+    );
+    guard.release().await.unwrap();
+    let g2 = mutexes[1].try_lock().await.unwrap();
+    assert!(g2.is_some(), "free lock must be try-lockable");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn unmutated_write_release_keeps_value() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let mesh = TestMesh::new(&all);
+    let mutexes = create_mutexes::<u64>(&mesh, &all, LockId::from_name("clean"), 41).await;
+
+    let guard = mutexes[1].lock().await.unwrap();
+    let version_before = guard.value_version();
+    guard.release().await.unwrap(); // never mutated: no value shipped
+
+    let guard = mutexes[2].lock().await.unwrap();
+    assert_eq!(*guard, 41);
+    assert_eq!(
+        guard.value_version(),
+        version_before,
+        "unmutated release must not advance the value version"
+    );
+}

--- a/netbeam/src/sync/group/lease.rs
+++ b/netbeam/src/sync/group/lease.rs
@@ -1,0 +1,203 @@
+//! Pure lease/janitor arithmetic. All instants are `millis` on the LOCAL monotonic
+//! clock (the driver supplies them); no cross-node clock value is ever compared.
+//!
+//! The steal rule (DynamoDB-lock-client pattern): freeze a snapshot of the blocker's
+//! progress counters at first observation; if, after `lease_duration + steal_grace`
+//! measured on the observer's own clock, the counters have not advanced, the blocker
+//! is steal-eligible. The CAS precondition re-checks the frozen snapshot, so a holder
+//! that advanced concurrently denies the steal — hints (like stream disconnects) may
+//! start observation early but can never force a transfer.
+
+use crate::sync::group::record::{HolderEntry, LockRecord, WaitEntry};
+use crate::sync::group::MemberId;
+
+/// Progress snapshot of a queue/holder entry that blocks us.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum BlockerSnapshot {
+    Holder {
+        member: MemberId,
+        nonce: u64,
+        fence: crate::sync::group::Fence,
+        lease_seq: u64,
+    },
+    Waiter {
+        member: MemberId,
+        nonce: u64,
+        refresh_seq: u64,
+    },
+}
+
+impl BlockerSnapshot {
+    pub fn of_holder(h: &HolderEntry) -> Self {
+        Self::Holder {
+            member: h.member,
+            nonce: h.nonce,
+            fence: h.fence,
+            lease_seq: h.lease_seq,
+        }
+    }
+
+    pub fn of_waiter(w: &WaitEntry) -> Self {
+        Self::Waiter {
+            member: w.member,
+            nonce: w.nonce,
+            refresh_seq: w.refresh_seq,
+        }
+    }
+}
+
+/// Tracks one blocker's observed (im)mobility on the local clock.
+#[derive(Clone, Debug)]
+pub struct ObservationWindow {
+    snapshot: BlockerSnapshot,
+    first_observed_ms: u64,
+}
+
+impl ObservationWindow {
+    pub fn start(snapshot: BlockerSnapshot, now_ms: u64) -> Self {
+        Self {
+            snapshot,
+            first_observed_ms: now_ms,
+        }
+    }
+
+    /// Re-observe. If the blocker advanced, the window restarts at `now_ms`.
+    /// Returns `true` if the snapshot was stagnant (window preserved).
+    pub fn observe(&mut self, current: BlockerSnapshot, now_ms: u64) -> bool {
+        if current == self.snapshot {
+            true
+        } else {
+            self.snapshot = current;
+            self.first_observed_ms = now_ms;
+            false
+        }
+    }
+
+    pub fn snapshot(&self) -> &BlockerSnapshot {
+        &self.snapshot
+    }
+
+    /// Steal/evict eligibility: stagnant for at least the full window.
+    pub fn is_expired(&self, now_ms: u64, window_ms: u64) -> bool {
+        now_ms.saturating_sub(self.first_observed_ms) >= window_ms
+    }
+}
+
+/// The single entry currently blocking `(member, nonce)`'s queue progress, if any:
+/// for a queued writer, the current holder set's first entry or its queue predecessor;
+/// for a queued reader, the nearest earlier queued writer or the current writer.
+/// Returns the snapshot the janitor should watch. `None` = nothing blocks (claim!).
+pub fn blocking_snapshot(
+    record: &LockRecord,
+    member: MemberId,
+    nonce: u64,
+) -> Option<BlockerSnapshot> {
+    use crate::sync::group::record::Holders;
+    use crate::sync::group::LockKind;
+
+    let (idx, entry) = record.wait_entry(member, nonce)?;
+    match entry.kind {
+        LockKind::Write => {
+            if idx > 0 {
+                return Some(BlockerSnapshot::of_waiter(&record.queue[idx - 1]));
+            }
+            match &record.holders {
+                Holders::None => None,
+                Holders::Writer(h) => Some(BlockerSnapshot::of_holder(h)),
+                // watch the reader batch's slowest-visible entry: any stagnant one
+                // must drain, so observe the first (they are stolen individually)
+                Holders::Readers(hs) => hs.first().map(BlockerSnapshot::of_holder),
+            }
+        }
+        LockKind::Read => {
+            if let Some(w) = record.queue[..idx]
+                .iter()
+                .rev()
+                .find(|w| w.kind == LockKind::Write)
+            {
+                return Some(BlockerSnapshot::of_waiter(w));
+            }
+            match &record.holders {
+                Holders::Writer(h) => Some(BlockerSnapshot::of_holder(h)),
+                _ => None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::group::record::{Holders, LockRecord};
+    use crate::sync::group::{Fence, LockKind};
+
+    #[test]
+    fn window_restarts_when_blocker_advances() {
+        let snap = BlockerSnapshot::Waiter {
+            member: MemberId(1),
+            nonce: 1,
+            refresh_seq: 0,
+        };
+        let mut w = ObservationWindow::start(snap, 1000);
+        assert!(!w.is_expired(1500, 1000));
+        assert!(w.observe(snap, 1500));
+        assert!(w.is_expired(2000, 1000));
+
+        let advanced = BlockerSnapshot::Waiter {
+            member: MemberId(1),
+            nonce: 1,
+            refresh_seq: 1,
+        };
+        assert!(!w.observe(advanced, 2000));
+        assert!(!w.is_expired(2500, 1000));
+        assert!(w.is_expired(3000, 1000));
+    }
+
+    #[test]
+    fn blocking_snapshot_selection() {
+        let mut rec = LockRecord::initial(vec![]);
+        rec.holders = Holders::Writer(HolderEntry {
+            member: MemberId(9),
+            nonce: 90,
+            fence: Fence(3),
+            lease_seq: 2,
+            recovered: None,
+        });
+        rec.queue = vec![
+            WaitEntry {
+                member: MemberId(1),
+                nonce: 10,
+                kind: LockKind::Write,
+                refresh_seq: 0,
+            },
+            WaitEntry {
+                member: MemberId(2),
+                nonce: 20,
+                kind: LockKind::Read,
+                refresh_seq: 5,
+            },
+        ];
+        // head writer watches the current writer-holder
+        assert_eq!(
+            blocking_snapshot(&rec, MemberId(1), 10),
+            Some(BlockerSnapshot::Holder {
+                member: MemberId(9),
+                nonce: 90,
+                fence: Fence(3),
+                lease_seq: 2
+            })
+        );
+        // the reader behind the queued writer watches that writer's wait entry
+        assert_eq!(
+            blocking_snapshot(&rec, MemberId(2), 20),
+            Some(BlockerSnapshot::Waiter {
+                member: MemberId(1),
+                nonce: 10,
+                refresh_seq: 0
+            })
+        );
+        // free lock + head of queue = nothing blocking
+        rec.holders = Holders::None;
+        assert_eq!(blocking_snapshot(&rec, MemberId(1), 10), None);
+    }
+}

--- a/netbeam/src/sync/group/mod.rs
+++ b/netbeam/src/sync/group/mod.rs
@@ -1,0 +1,154 @@
+//! # N-Node Group Synchronization Primitives
+//!
+//! Fault-tolerant distributed lock primitives for `n >= 2` members connected by a
+//! full mesh of [`crate::reliable_conn::ReliableOrderedStreamToTarget`] pipes.
+//!
+//! Unlike the 2-node primitives in [`crate::sync::primitives`], these tolerate
+//! `f < n/2` member crashes and arbitrary network partitions while preserving
+//! mutual exclusion of grant epochs (safety) — liveness requires a connected
+//! majority of the configured membership.
+//!
+//! ## Algorithm
+//! Each lock is a single replicated register (a [`record::LockRecord`]) maintained by a
+//! CASPaxos-style consensus round: every lock operation is a pure compare-and-swap
+//! ([`ops::apply`]) proposed via Prepare/Promise → Accept/Accepted against a majority
+//! of the members. There is no leader and no election. Grants carry:
+//! - a **lease** measured on each observer's local monotonic clock (never wall clocks),
+//! - a monotonic **fencing token** ([`Fence`]) that external systems can verify,
+//! - a **recovered** flag when the previous writer crashed mid-critical-section.
+//!
+//! Crashed holders are removed by a *steal* CAS gated on a frozen `(fence, lease_seq)`
+//! snapshot observed unchanged for `lease_duration + steal_grace` on the stealer's own
+//! clock. A steal never grants the lock to anyone: the next holder must run its own
+//! claim round, which structurally eliminates stale-grant races.
+//!
+//! ## Modules
+//! Pure (no I/O, no clocks — deterministic unit tests): [`record`], [`ops`],
+//! [`admission`], [`acceptor`], [`lease`], [`wire`], [`config`], [`error`].
+//! Async drivers: [`transport`], [`proposer`], [`engine`], [`guard`],
+//! [`mutex`], [`rwlock`].
+
+use serde::{Deserialize, Serialize};
+
+pub mod acceptor;
+pub(crate) mod acquire;
+pub(crate) mod acquire_wait;
+pub mod admission;
+pub mod config;
+pub(crate) mod create;
+pub mod engine;
+pub(crate) mod engine_util;
+pub mod error;
+pub(crate) mod grant_state;
+pub mod guard;
+pub mod lease;
+pub mod mutex;
+pub mod op_types;
+pub mod ops;
+pub(crate) mod ops_grant;
+pub mod persist;
+pub mod proposer;
+pub mod record;
+pub mod rwlock;
+#[cfg(not(target_family = "wasm"))]
+pub mod test_mesh;
+pub mod transport;
+pub mod wire;
+
+pub use config::GroupLockConfig;
+pub use error::GroupLockError;
+pub use guard::{NetGroupReadGuard, NetGroupWriteGuard};
+pub use mutex::{NetGroupMutex, NetGroupMutexGuard};
+pub use persist::{peek_value, SnapshotAcceptorStore};
+pub use rwlock::NetGroupRwLock;
+pub use transport::GroupTransport;
+
+/// Stable, unique identity of a member within a lock group. The total order over
+/// member ids doubles as the ballot tiebreak, so ids must be unique across the group.
+#[derive(
+    Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default,
+)]
+pub struct MemberId(pub u64);
+
+/// Caller-assigned identity of a lock instance; must be identical on every member.
+#[derive(
+    Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default,
+)]
+pub struct LockId(pub u64);
+
+impl LockId {
+    /// Derives a `LockId` from a human-readable name via FNV-1a, so all members can
+    /// agree on an id without coordinating (`LockId::from_name("session-counter")`).
+    pub fn from_name(name: &str) -> Self {
+        Self(fnv1a(name.as_bytes()))
+    }
+}
+
+/// Monotonic fencing token. A new fence is minted for every grant (read or write),
+/// strictly increasing across the lock's linearized history. Pass it to external
+/// systems so they can reject operations from stale (paused/partitioned) holders.
+#[derive(
+    Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default,
+)]
+pub struct Fence(pub u64);
+
+/// The mode a lock is held or requested in.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum LockKind {
+    Read,
+    Write,
+}
+
+pub(crate) fn fnv1a(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET;
+    for b in bytes {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+#[path = "ops_tests.rs"]
+mod ops_tests;
+
+#[cfg(test)]
+#[path = "ops_tests_fault.rs"]
+mod ops_tests_fault;
+
+#[cfg(test)]
+#[path = "ops_tests_replay.rs"]
+mod ops_tests_replay;
+
+#[cfg(all(test, not(target_family = "wasm")))]
+#[path = "integration_tests.rs"]
+mod integration_tests;
+
+#[cfg(all(test, not(target_family = "wasm")))]
+#[path = "fault_tests.rs"]
+mod fault_tests;
+
+#[cfg(all(test, not(target_family = "wasm")))]
+#[path = "persist_tests.rs"]
+mod persist_tests;
+
+#[cfg(test)]
+#[path = "sim_tests.rs"]
+mod sim_tests;
+
+#[cfg(test)]
+#[path = "adversary_tests.rs"]
+mod adversary_tests;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_id_from_name_is_stable_and_distinct() {
+        assert_eq!(LockId::from_name("a"), LockId::from_name("a"));
+        assert_ne!(LockId::from_name("a"), LockId::from_name("b"));
+    }
+}

--- a/netbeam/src/sync/group/mutex.rs
+++ b/netbeam/src/sync/group/mutex.rs
@@ -1,0 +1,96 @@
+//! N-node fault-tolerant mutex: the write-only facade over the group lock engine.
+//!
+//! ```ignore
+//! let transport = GroupTransport::new(local_id, peer_streams);
+//! let mutex = NetGroupMutex::<u64>::create(
+//!     transport, LockId::from_name("counter"), cfg, store, Some(0)).await?;
+//! let mut guard = mutex.lock().await?;
+//! *guard += 1; // propagated to a majority atomically with the release
+//! drop(guard);
+//! ```
+//!
+//! Every member of the group must `create()` the lock (each runs a consensus voter);
+//! exactly the configured `initial_value_owner` passes `Some(initial)`. Keep the
+//! `NetGroupMutex` alive until all its guards are released: dropping it shuts down
+//! the engine's message routing.
+
+use crate::sync::group::acceptor::AcceptorStateStore;
+use crate::sync::group::config::GroupLockConfig;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::guard::NetGroupWriteGuard;
+use crate::sync::group::transport::GroupTransport;
+use crate::sync::group::{LockId, LockKind};
+use crate::sync::primitives::NetObject;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// The guard returned by [`NetGroupMutex::lock`]. See [`NetGroupWriteGuard`] for the
+/// fence/validity/recovery API. (`downgrade` is available but only meaningful for
+/// groups that also use [`crate::sync::group::rwlock::NetGroupRwLock`] semantics.)
+pub type NetGroupMutexGuard<T> = NetGroupWriteGuard<T>;
+
+pub struct NetGroupMutex<T: NetObject> {
+    engine: Arc<Engine>,
+    _pd: PhantomData<fn() -> T>,
+}
+
+impl<T: NetObject> NetGroupMutex<T> {
+    /// Joins (and on the owner, initializes) the distributed mutex `lock_id` over
+    /// `transport`. Blocks until the initial value is established on a majority
+    /// (bounded by `cfg.acquire_timeout()`).
+    pub async fn create(
+        transport: Arc<GroupTransport>,
+        lock_id: LockId,
+        cfg: GroupLockConfig,
+        store: Arc<dyn AcceptorStateStore>,
+        initial: Option<T>,
+    ) -> Result<Self, GroupLockError> {
+        let engine =
+            crate::sync::group::create::create_engine(transport, lock_id, cfg, store, initial)
+                .await?;
+        Ok(Self {
+            engine,
+            _pd: PhantomData,
+        })
+    }
+
+    /// Acquires the lock, waiting in the group-wide FIFO queue. Bounded by
+    /// `cfg.acquire_timeout()`.
+    pub async fn lock(&self) -> Result<NetGroupMutexGuard<T>, GroupLockError> {
+        self.lock_with_timeout(self.engine.cfg.acquire_timeout())
+            .await
+    }
+
+    /// Acquires with an explicit deadline.
+    pub async fn lock_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<NetGroupMutexGuard<T>, GroupLockError> {
+        let grant = self.engine.acquire(LockKind::Write, false, timeout).await?;
+        NetGroupWriteGuard::from_grant(self.engine.clone(), grant)
+    }
+
+    /// Single-round attempt: `Ok(None)` if the lock is currently contended.
+    pub async fn try_lock(&self) -> Result<Option<NetGroupMutexGuard<T>>, GroupLockError> {
+        match self
+            .engine
+            .acquire(LockKind::Write, true, self.engine.cfg.round_timeout())
+            .await
+        {
+            Ok(grant) => Ok(Some(NetGroupWriteGuard::from_grant(
+                self.engine.clone(),
+                grant,
+            )?)),
+            Err(GroupLockError::WouldBlock) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl<T: NetObject> Drop for NetGroupMutex<T> {
+    fn drop(&mut self) {
+        self.engine.shutdown();
+    }
+}

--- a/netbeam/src/sync/group/op_types.rs
+++ b/netbeam/src/sync/group/op_types.rs
@@ -1,0 +1,115 @@
+//! Operation, outcome, and denial types for the pure CAS transition function
+//! [`crate::sync::group::ops::apply`].
+
+use crate::sync::group::record::PoisonInfo;
+use crate::sync::group::{Fence, LockKind, MemberId};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub enum Op {
+    /// Bootstrap by `initial_value_owner`: creates the record with the initial value.
+    Init { value: Vec<u8> },
+    /// Grant immediately if the write-preferring FIFO rule allows, else append a
+    /// wait entry (unless `no_enqueue`, the `try_*` path).
+    AcquireOrEnqueue {
+        member: MemberId,
+        nonce: u64,
+        kind: LockKind,
+        no_enqueue: bool,
+    },
+    /// Promote own queue entry to a grant; the requester proving its liveness by
+    /// running this round IS the grant-time revalidation (a dead entry never claims).
+    ClaimQueued { member: MemberId, nonce: u64 },
+    /// Waiter heartbeat: bump own entry's `refresh_seq`.
+    RefreshWait { member: MemberId, nonce: u64 },
+    /// Holder heartbeat: bump own `lease_seq`.
+    Renew {
+        member: MemberId,
+        nonce: u64,
+        expect_fence: Fence,
+        expect_lease_seq: u64,
+    },
+    /// Remove own grant; `new_value` (serialized T) commits atomically when the
+    /// critical section mutated the value.
+    Release {
+        member: MemberId,
+        nonce: u64,
+        expect_fence: Fence,
+        new_value: Option<Vec<u8>>,
+    },
+    /// Atomically convert own write grant into a read grant (fresh fence), publishing
+    /// `new_value` if mutated. No upgrade op exists: read→write upgrades deadlock.
+    Downgrade {
+        member: MemberId,
+        nonce: u64,
+        expect_fence: Fence,
+        new_value: Option<Vec<u8>>,
+    },
+    /// Remove a stagnant holder observed frozen at `(expect_fence, expect_lease_seq)`
+    /// for a full locally-timed lease window. Poisons the record iff the target held
+    /// Write. Never grants: the beneficiary must run its own `ClaimQueued`.
+    Steal {
+        target: MemberId,
+        target_nonce: u64,
+        expect_fence: Fence,
+        expect_lease_seq: u64,
+    },
+    /// Remove a stagnant waiter observed frozen at `expect_refresh_seq`.
+    EvictWaiter {
+        target: MemberId,
+        target_nonce: u64,
+        expect_refresh_seq: u64,
+    },
+    /// Cancel own pending request. If the request raced a grant (committed but never
+    /// observed), the grant is revoked WITHOUT poison — the canceller provably never
+    /// entered the critical section — and any poison it had consumed is restored.
+    Dequeue { member: MemberId, nonce: u64 },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OpOutcome {
+    Initialized,
+    Granted {
+        fence: Fence,
+        recovered: Option<PoisonInfo>,
+    },
+    Enqueued {
+        position: usize,
+    },
+    Refreshed,
+    Renewed {
+        lease_seq: u64,
+    },
+    Released,
+    Downgraded {
+        fence: Fence,
+    },
+    Stolen,
+    Evicted,
+    Dequeued {
+        was_granted: bool,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OpDenied {
+    /// No committed record yet; only `Init` may apply.
+    Uninitialized,
+    /// `Init` against an existing record.
+    AlreadyInitialized,
+    /// `no_enqueue` acquire on a contended lock.
+    WouldBlock,
+    /// Claim attempted while the entry is not admissible (or missing).
+    NotAdmissible,
+    /// The `(member, nonce)` wait entry is gone (evicted or never enqueued).
+    NotQueued,
+    /// The `(member, nonce)` holder entry is gone or its fence/seq moved on —
+    /// the grant was stolen (or this is a stale retry of an applied op).
+    NotHolder,
+    /// Steal/EvictWaiter snapshot mismatch: the target advanced (it is alive).
+    SnapshotMismatch,
+    /// Steal/EvictWaiter target already removed. Success-equivalent for the caller.
+    TargetGone,
+    /// A record counter would overflow (defensive; unreachable via honest peers).
+    CounterExhausted,
+}

--- a/netbeam/src/sync/group/ops.rs
+++ b/netbeam/src/sync/group/ops.rs
@@ -1,0 +1,238 @@
+//! Every lock-semantic transition, expressed as one pure compare-and-swap function:
+//! [`apply`]. All safety preconditions live here; the consensus layer merely
+//! linearizes calls to this function. Every op is idempotent under re-application
+//! after an ambiguous (timed-out) round — grants record their consumed poison in
+//! the holder entry so a retried acquire/claim reports the same `recovered` info.
+
+use crate::sync::group::admission;
+use crate::sync::group::op_types::{Op, OpDenied, OpOutcome};
+use crate::sync::group::ops_grant::grant;
+use crate::sync::group::record::{HolderEntry, Holders, LockRecord, PoisonInfo, WaitEntry};
+use crate::sync::group::LockKind;
+
+/// The pure CAS transition. Returns `(successor_record, outcome)`; a denial leaves
+/// the record untouched (the proposer commits an identity write to linearize it).
+pub fn apply(current: Option<&LockRecord>, op: &Op) -> Result<(LockRecord, OpOutcome), OpDenied> {
+    let mut rec = match (current, op) {
+        (None, Op::Init { value }) => {
+            return Ok((LockRecord::initial(value.clone()), OpOutcome::Initialized))
+        }
+        (Some(_), Op::Init { .. }) => return Err(OpDenied::AlreadyInitialized),
+        (None, _) => return Err(OpDenied::Uninitialized),
+        (Some(rec), _) => rec.clone(),
+    };
+
+    match op {
+        Op::Init { .. } => unreachable!("handled above"),
+
+        Op::AcquireOrEnqueue {
+            member,
+            nonce,
+            kind,
+            no_enqueue,
+        } => {
+            if let Some(h) = rec.holder(*member, *nonce) {
+                // idempotent retry of a committed grant
+                let outcome = OpOutcome::Granted {
+                    fence: h.fence,
+                    recovered: h.recovered.clone(),
+                };
+                return Ok((rec, outcome));
+            }
+            if let Some((pos, _)) = rec.wait_entry(*member, *nonce) {
+                return Ok((rec, OpOutcome::Enqueued { position: pos }));
+            }
+            if admission::immediate_grant_allowed(&rec, *kind) {
+                let outcome = grant(&mut rec, *member, *nonce, *kind)?;
+                Ok((rec, outcome))
+            } else if *no_enqueue {
+                Err(OpDenied::WouldBlock)
+            } else {
+                rec.queue.push(WaitEntry {
+                    member: *member,
+                    nonce: *nonce,
+                    kind: *kind,
+                    refresh_seq: 0,
+                });
+                let position = rec.queue.len() - 1;
+                Ok((rec, OpOutcome::Enqueued { position }))
+            }
+        }
+
+        Op::ClaimQueued { member, nonce } => {
+            if let Some(h) = rec.holder(*member, *nonce) {
+                let outcome = OpOutcome::Granted {
+                    fence: h.fence,
+                    recovered: h.recovered.clone(),
+                };
+                return Ok((rec, outcome));
+            }
+            if rec.wait_entry(*member, *nonce).is_none() {
+                return Err(OpDenied::NotQueued);
+            }
+            if !admission::is_admissible(&rec, *member, *nonce) {
+                return Err(OpDenied::NotAdmissible);
+            }
+            let entry = rec.remove_wait_entry(*member, *nonce).expect("checked");
+            let outcome = grant(&mut rec, *member, *nonce, entry.kind)?;
+            Ok((rec, outcome))
+        }
+
+        Op::RefreshWait { member, nonce } => {
+            if rec.holder(*member, *nonce).is_some() {
+                // raced a grant; the waiter will discover this on its next claim
+                return Err(OpDenied::NotQueued);
+            }
+            let Some(idx) = rec
+                .queue
+                .iter()
+                .position(|w| w.member == *member && w.nonce == *nonce)
+            else {
+                return Err(OpDenied::NotQueued);
+            };
+            rec.queue[idx].refresh_seq = rec.queue[idx]
+                .refresh_seq
+                .checked_add(1)
+                .ok_or(OpDenied::CounterExhausted)?;
+            Ok((rec, OpOutcome::Refreshed))
+        }
+
+        Op::Renew {
+            member,
+            nonce,
+            expect_fence,
+            expect_lease_seq,
+        } => {
+            let Some(h) = rec.holder_mut(*member, *nonce) else {
+                return Err(OpDenied::NotHolder);
+            };
+            if h.fence != *expect_fence {
+                return Err(OpDenied::NotHolder);
+            }
+            if h.lease_seq == *expect_lease_seq {
+                h.lease_seq = h
+                    .lease_seq
+                    .checked_add(1)
+                    .ok_or(OpDenied::CounterExhausted)?;
+            } else if h.lease_seq != *expect_lease_seq + 1 {
+                // neither fresh nor an idempotent replay of the previous renew
+                return Err(OpDenied::NotHolder);
+            }
+            let lease_seq = h.lease_seq;
+            Ok((rec, OpOutcome::Renewed { lease_seq }))
+        }
+
+        Op::Release {
+            member,
+            nonce,
+            expect_fence,
+            new_value,
+        } => {
+            if rec.holder(*member, *nonce).is_none() {
+                // idempotent replay of a committed release (tombstone or value fence)
+                if rec.last_released == Some((*member, *nonce, *expect_fence))
+                    || (new_value.is_some() && rec.value_version == *expect_fence)
+                {
+                    return Ok((rec, OpOutcome::Released));
+                }
+                return Err(OpDenied::NotHolder);
+            }
+            let (h, _) = rec.remove_holder(*member, *nonce).expect("checked above");
+            if h.fence != *expect_fence {
+                return Err(OpDenied::NotHolder);
+            }
+            if let Some(v) = new_value {
+                rec.value = v.clone();
+                rec.value_version = *expect_fence;
+            }
+            rec.last_released = Some((*member, *nonce, *expect_fence));
+            Ok((rec, OpOutcome::Released))
+        }
+
+        Op::Downgrade {
+            member,
+            nonce,
+            expect_fence,
+            new_value,
+        } => {
+            // idempotent replay: a committed downgrade left this (member, nonce) as
+            // a reader entry (nonces are per-acquire, so aliasing is impossible)
+            if let (Holders::Readers(_), Some(h)) = (&rec.holders, rec.holder(*member, *nonce)) {
+                let fence = h.fence;
+                return Ok((rec, OpOutcome::Downgraded { fence }));
+            }
+            match &rec.holders {
+                Holders::Writer(h)
+                    if h.member == *member && h.nonce == *nonce && h.fence == *expect_fence => {}
+                _ => return Err(OpDenied::NotHolder),
+            }
+            if let Some(v) = new_value {
+                rec.value = v.clone();
+                rec.value_version = *expect_fence;
+            }
+            let fence = rec.next_fence().ok_or(OpDenied::CounterExhausted)?;
+            rec.holders = Holders::Readers(vec![HolderEntry {
+                member: *member,
+                nonce: *nonce,
+                fence,
+                lease_seq: 0,
+                recovered: None,
+            }]);
+            Ok((rec, OpOutcome::Downgraded { fence }))
+        }
+
+        Op::Steal {
+            target,
+            target_nonce,
+            expect_fence,
+            expect_lease_seq,
+        } => {
+            let Some(h) = rec.holder(*target, *target_nonce) else {
+                return Err(OpDenied::TargetGone);
+            };
+            if h.fence != *expect_fence || h.lease_seq != *expect_lease_seq {
+                return Err(OpDenied::SnapshotMismatch);
+            }
+            let (h, kind) = rec
+                .remove_holder(*target, *target_nonce)
+                .expect("checked above");
+            if kind == LockKind::Write {
+                rec.poisoned = Some(PoisonInfo {
+                    member: h.member,
+                    fence: h.fence,
+                });
+            }
+            Ok((rec, OpOutcome::Stolen))
+        }
+
+        Op::EvictWaiter {
+            target,
+            target_nonce,
+            expect_refresh_seq,
+        } => {
+            let Some((_, w)) = rec.wait_entry(*target, *target_nonce) else {
+                return Err(OpDenied::TargetGone);
+            };
+            if w.refresh_seq != *expect_refresh_seq {
+                return Err(OpDenied::SnapshotMismatch);
+            }
+            rec.remove_wait_entry(*target, *target_nonce);
+            Ok((rec, OpOutcome::Evicted))
+        }
+
+        Op::Dequeue { member, nonce } => {
+            if rec.remove_wait_entry(*member, *nonce).is_some() {
+                return Ok((rec, OpOutcome::Dequeued { was_granted: false }));
+            }
+            if let Some((h, _)) = rec.remove_holder(*member, *nonce) {
+                // cancel raced the grant: revoke without poison, restoring any
+                // poison this grant had consumed (the CS provably never ran)
+                if rec.poisoned.is_none() {
+                    rec.poisoned = h.recovered;
+                }
+                return Ok((rec, OpOutcome::Dequeued { was_granted: true }));
+            }
+            Err(OpDenied::NotQueued)
+        }
+    }
+}

--- a/netbeam/src/sync/group/ops_grant.rs
+++ b/netbeam/src/sync/group/ops_grant.rs
@@ -1,0 +1,38 @@
+//! Grant issuance: mints the fence, consumes poison (write grants), and installs
+//! the holder entry. Split from `ops.rs` (single caller set: the apply() arms).
+
+use crate::sync::group::op_types::{OpDenied, OpOutcome};
+use crate::sync::group::record::{HolderEntry, Holders, LockRecord};
+use crate::sync::group::{LockKind, MemberId};
+
+pub(super) fn grant(
+    rec: &mut LockRecord,
+    member: MemberId,
+    nonce: u64,
+    kind: LockKind,
+) -> Result<OpOutcome, OpDenied> {
+    let fence = rec.next_fence().ok_or(OpDenied::CounterExhausted)?;
+    let recovered = match kind {
+        LockKind::Write => rec.poisoned.take(),
+        LockKind::Read => None,
+    };
+    let entry = HolderEntry {
+        member,
+        nonce,
+        fence,
+        lease_seq: 0,
+        recovered: recovered.clone(),
+    };
+    match (&mut rec.holders, kind) {
+        (Holders::Readers(hs), LockKind::Read) => hs.push(entry),
+        (holders @ Holders::None, LockKind::Read) => *holders = Holders::Readers(vec![entry]),
+        (holders, LockKind::Write) => {
+            debug_assert!(matches!(holders, Holders::None));
+            *holders = Holders::Writer(entry);
+        }
+        (Holders::Writer(_), LockKind::Read) => {
+            unreachable!("admission forbids read grants while a writer holds")
+        }
+    }
+    Ok(OpOutcome::Granted { fence, recovered })
+}

--- a/netbeam/src/sync/group/ops_tests.rs
+++ b/netbeam/src/sync/group/ops_tests.rs
@@ -1,0 +1,239 @@
+//! Table tests for every `apply()` precondition (loaded from ops.rs as
+//! `#[cfg(test)] #[path = "ops_tests.rs"]`).
+
+use crate::sync::group::op_types::{Op, OpDenied, OpOutcome};
+use crate::sync::group::ops::apply;
+use crate::sync::group::record::{Holders, LockRecord};
+use crate::sync::group::{Fence, LockKind, MemberId};
+
+pub(super) fn m(id: u64) -> MemberId {
+    MemberId(id)
+}
+
+pub(super) fn init() -> LockRecord {
+    apply(None, &Op::Init { value: vec![7] }).unwrap().0
+}
+
+pub(super) fn acquire(
+    rec: &LockRecord,
+    member: u64,
+    nonce: u64,
+    kind: LockKind,
+) -> (LockRecord, OpOutcome) {
+    apply(
+        Some(rec),
+        &Op::AcquireOrEnqueue {
+            member: m(member),
+            nonce,
+            kind,
+            no_enqueue: false,
+        },
+    )
+    .unwrap()
+}
+
+#[test]
+fn init_only_from_none() {
+    let rec = init();
+    assert_eq!(rec.value, vec![7]);
+    assert_eq!(
+        apply(Some(&rec), &Op::Init { value: vec![8] }).unwrap_err(),
+        OpDenied::AlreadyInitialized
+    );
+    assert_eq!(
+        apply(
+            None,
+            &Op::ClaimQueued {
+                member: m(1),
+                nonce: 1
+            }
+        )
+        .unwrap_err(),
+        OpDenied::Uninitialized
+    );
+}
+
+#[test]
+fn immediate_grant_then_fifo_enqueue() {
+    let rec = init();
+    let (rec, out) = acquire(&rec, 1, 10, LockKind::Write);
+    let fence = match out {
+        OpOutcome::Granted { fence, recovered } => {
+            assert!(recovered.is_none());
+            fence
+        }
+        other => panic!("expected grant, got {other:?}"),
+    };
+    assert_eq!(fence, Fence(1));
+
+    // second writer queues; retry of the same request is idempotent
+    let (rec, out) = acquire(&rec, 2, 20, LockKind::Write);
+    assert_eq!(out, OpOutcome::Enqueued { position: 0 });
+    let (rec, out) = acquire(&rec, 2, 20, LockKind::Write);
+    assert_eq!(out, OpOutcome::Enqueued { position: 0 });
+
+    // retry of the holder's own acquire returns the same grant
+    let (_, out) = acquire(&rec, 1, 10, LockKind::Write);
+    assert_eq!(
+        out,
+        OpOutcome::Granted {
+            fence,
+            recovered: None
+        }
+    );
+}
+
+#[test]
+fn try_acquire_would_block() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    let denied = apply(
+        Some(&rec),
+        &Op::AcquireOrEnqueue {
+            member: m(2),
+            nonce: 20,
+            kind: LockKind::Write,
+            no_enqueue: true,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(denied, OpDenied::WouldBlock);
+    assert!(rec.queue.is_empty());
+}
+
+#[test]
+fn claim_respects_admission_and_liveness() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    let (rec, _) = acquire(&rec, 2, 20, LockKind::Write);
+
+    // not admissible while the holder lives
+    assert_eq!(
+        apply(
+            Some(&rec),
+            &Op::ClaimQueued {
+                member: m(2),
+                nonce: 20
+            }
+        )
+        .unwrap_err(),
+        OpDenied::NotAdmissible
+    );
+    // never-queued member cannot claim
+    assert_eq!(
+        apply(
+            Some(&rec),
+            &Op::ClaimQueued {
+                member: m(3),
+                nonce: 30
+            }
+        )
+        .unwrap_err(),
+        OpDenied::NotQueued
+    );
+
+    // after release, the head claims; fences strictly increase
+    let (rec, _) = apply(
+        Some(&rec),
+        &Op::Release {
+            member: m(1),
+            nonce: 10,
+            expect_fence: Fence(1),
+            new_value: None,
+        },
+    )
+    .unwrap();
+    let (rec, out) = apply(
+        Some(&rec),
+        &Op::ClaimQueued {
+            member: m(2),
+            nonce: 20,
+        },
+    )
+    .unwrap();
+    assert!(matches!(out, OpOutcome::Granted { fence, .. } if fence == Fence(2)));
+    assert!(rec.queue.is_empty());
+}
+
+#[test]
+fn renew_is_idempotent_and_fenced() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    let renew = |rec: &LockRecord, seq: u64| {
+        apply(
+            Some(rec),
+            &Op::Renew {
+                member: m(1),
+                nonce: 10,
+                expect_fence: Fence(1),
+                expect_lease_seq: seq,
+            },
+        )
+    };
+    let (rec, out) = renew(&rec, 0).unwrap();
+    assert_eq!(out, OpOutcome::Renewed { lease_seq: 1 });
+    // replay of the same renew: accepted without double-increment
+    let (rec, out) = renew(&rec, 0).unwrap();
+    assert_eq!(out, OpOutcome::Renewed { lease_seq: 1 });
+    // stale-by-two renews and wrong fences are denied
+    assert!(matches!(
+        apply(
+            Some(&rec),
+            &Op::Renew {
+                member: m(1),
+                nonce: 10,
+                expect_fence: Fence(9),
+                expect_lease_seq: 1
+            }
+        ),
+        Err(OpDenied::NotHolder)
+    ));
+    let (rec, _) = renew(&rec, 1).unwrap();
+    assert!(matches!(renew(&rec, 0), Err(OpDenied::NotHolder)));
+}
+
+#[test]
+fn release_commits_value_atomically_and_replays() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    let release = Op::Release {
+        member: m(1),
+        nonce: 10,
+        expect_fence: Fence(1),
+        new_value: Some(vec![42]),
+    };
+    let (rec, _) = apply(Some(&rec), &release).unwrap();
+    assert_eq!(rec.value, vec![42]);
+    assert_eq!(rec.value_version, Fence(1));
+    assert_eq!(rec.holders, Holders::None);
+    // replay after commit is recognized via value_version
+    let (rec2, out) = apply(Some(&rec), &release).unwrap();
+    assert_eq!(out, OpOutcome::Released);
+    assert_eq!(rec2, rec);
+    // value-less replay is recognized via the last_released tombstone
+    let (rec3, out) = apply(
+        Some(&rec),
+        &Op::Release {
+            member: m(1),
+            nonce: 10,
+            expect_fence: Fence(1),
+            new_value: None,
+        },
+    )
+    .unwrap();
+    assert_eq!(out, OpOutcome::Released);
+    assert_eq!(rec3, rec);
+    // a stranger's release is still denied
+    assert!(matches!(
+        apply(
+            Some(&rec),
+            &Op::Release {
+                member: m(9),
+                nonce: 99,
+                expect_fence: Fence(1),
+                new_value: None
+            }
+        ),
+        Err(OpDenied::NotHolder)
+    ));
+}

--- a/netbeam/src/sync/group/ops_tests_fault.rs
+++ b/netbeam/src/sync/group/ops_tests_fault.rs
@@ -1,0 +1,221 @@
+//! Table tests for apply(): steal/evict/dequeue/downgrade preconditions.
+
+use super::ops_tests::{acquire, init, m};
+use crate::sync::group::op_types::{Op, OpDenied, OpOutcome};
+use crate::sync::group::ops::apply;
+use crate::sync::group::record::Holders;
+use crate::sync::group::{Fence, LockKind};
+
+#[test]
+fn steal_poisons_writers_only_and_next_write_grant_recovers() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    // alive holder (advanced seq) denies the steal
+    let (rec, _) = apply(
+        Some(&rec),
+        &Op::Renew {
+            member: m(1),
+            nonce: 10,
+            expect_fence: Fence(1),
+            expect_lease_seq: 0,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        apply(
+            Some(&rec),
+            &Op::Steal {
+                target: m(1),
+                target_nonce: 10,
+                expect_fence: Fence(1),
+                expect_lease_seq: 0
+            }
+        )
+        .unwrap_err(),
+        OpDenied::SnapshotMismatch
+    );
+    // matching frozen snapshot steals + poisons
+    let (rec, out) = apply(
+        Some(&rec),
+        &Op::Steal {
+            target: m(1),
+            target_nonce: 10,
+            expect_fence: Fence(1),
+            expect_lease_seq: 1,
+        },
+    )
+    .unwrap();
+    assert_eq!(out, OpOutcome::Stolen);
+    assert!(rec.poisoned.is_some());
+    // double steal: target gone
+    assert_eq!(
+        apply(
+            Some(&rec),
+            &Op::Steal {
+                target: m(1),
+                target_nonce: 10,
+                expect_fence: Fence(1),
+                expect_lease_seq: 1
+            }
+        )
+        .unwrap_err(),
+        OpDenied::TargetGone
+    );
+    // next write grant consumes the poison as `recovered`
+    let (rec, out) = acquire(&rec, 2, 20, LockKind::Write);
+    match out {
+        OpOutcome::Granted { recovered, .. } => {
+            assert_eq!(recovered.unwrap().member, m(1));
+        }
+        other => panic!("expected grant, got {other:?}"),
+    }
+    assert!(rec.poisoned.is_none());
+}
+
+#[test]
+fn steal_of_reader_does_not_poison() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Read);
+    let (rec, out) = apply(
+        Some(&rec),
+        &Op::Steal {
+            target: m(1),
+            target_nonce: 10,
+            expect_fence: Fence(1),
+            expect_lease_seq: 0,
+        },
+    )
+    .unwrap();
+    assert_eq!(out, OpOutcome::Stolen);
+    assert!(rec.poisoned.is_none());
+}
+
+#[test]
+fn evict_waiter_by_frozen_refresh_seq() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    let (rec, _) = acquire(&rec, 2, 20, LockKind::Write);
+    let (rec, _) = apply(
+        Some(&rec),
+        &Op::RefreshWait {
+            member: m(2),
+            nonce: 20,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        apply(
+            Some(&rec),
+            &Op::EvictWaiter {
+                target: m(2),
+                target_nonce: 20,
+                expect_refresh_seq: 0
+            }
+        )
+        .unwrap_err(),
+        OpDenied::SnapshotMismatch
+    );
+    let (rec, out) = apply(
+        Some(&rec),
+        &Op::EvictWaiter {
+            target: m(2),
+            target_nonce: 20,
+            expect_refresh_seq: 1,
+        },
+    )
+    .unwrap();
+    assert_eq!(out, OpOutcome::Evicted);
+    assert!(rec.queue.is_empty());
+}
+
+#[test]
+fn dequeue_races_grant_restores_poison_and_never_poisons_itself() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    // poison via steal, then member 2 acquires (consuming poison into its entry)
+    let (rec, _) = apply(
+        Some(&rec),
+        &Op::Steal {
+            target: m(1),
+            target_nonce: 10,
+            expect_fence: Fence(1),
+            expect_lease_seq: 0,
+        },
+    )
+    .unwrap();
+    let (rec, out) = acquire(&rec, 2, 20, LockKind::Write);
+    assert!(matches!(out, OpOutcome::Granted { ref recovered, .. } if recovered.is_some()));
+    assert!(rec.poisoned.is_none());
+    // member 2's cancel raced its own grant: revoke without poisoning, but the
+    // original crash signal is restored for the next writer
+    let (rec, out) = apply(
+        Some(&rec),
+        &Op::Dequeue {
+            member: m(2),
+            nonce: 20,
+        },
+    )
+    .unwrap();
+    assert_eq!(out, OpOutcome::Dequeued { was_granted: true });
+    assert_eq!(rec.holders, Holders::None);
+    assert_eq!(rec.poisoned.as_ref().unwrap().member, m(1));
+    // plain dequeue from the queue
+    let (rec, _) = acquire(&rec, 3, 30, LockKind::Write);
+    let (rec, _) = acquire(&rec, 4, 40, LockKind::Write);
+    let (rec, out) = apply(
+        Some(&rec),
+        &Op::Dequeue {
+            member: m(4),
+            nonce: 40,
+        },
+    )
+    .unwrap();
+    assert_eq!(out, OpOutcome::Dequeued { was_granted: false });
+    assert!(rec.queue.is_empty());
+}
+
+#[test]
+fn downgrade_mints_fresh_fence_and_publishes_value() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    let (rec, out) = apply(
+        Some(&rec),
+        &Op::Downgrade {
+            member: m(1),
+            nonce: 10,
+            expect_fence: Fence(1),
+            new_value: Some(vec![9]),
+        },
+    )
+    .unwrap();
+    assert_eq!(out, OpOutcome::Downgraded { fence: Fence(2) });
+    assert_eq!(rec.value, vec![9]);
+    assert_eq!(rec.value_version, Fence(1));
+    assert!(matches!(&rec.holders, Holders::Readers(hs) if hs.len() == 1));
+    // same-identity downgrade against the reader entry = idempotent replay
+    assert!(matches!(
+        apply(
+            Some(&rec),
+            &Op::Downgrade {
+                member: m(1),
+                nonce: 10,
+                expect_fence: Fence(1),
+                new_value: None
+            }
+        ),
+        Ok((_, OpOutcome::Downgraded { fence: Fence(2) }))
+    ));
+    // a different identity (an ordinary reader) cannot downgrade
+    assert!(matches!(
+        apply(
+            Some(&rec),
+            &Op::Downgrade {
+                member: m(2),
+                nonce: 20,
+                expect_fence: Fence(2),
+                new_value: None
+            }
+        ),
+        Err(OpDenied::NotHolder)
+    ));
+}

--- a/netbeam/src/sync/group/ops_tests_replay.rs
+++ b/netbeam/src/sync/group/ops_tests_replay.rs
@@ -1,0 +1,41 @@
+//! Table tests for apply() idempotent-replay branches (ambiguous committed rounds).
+
+use super::ops_tests::{acquire, init, m};
+use crate::sync::group::op_types::{Op, OpOutcome};
+use crate::sync::group::ops::apply;
+use crate::sync::group::{Fence, LockKind};
+
+#[test]
+fn downgrade_replay_is_idempotent() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Write);
+    let op = Op::Downgrade {
+        member: m(1),
+        nonce: 10,
+        expect_fence: Fence(1),
+        new_value: Some(vec![9]),
+    };
+    let (rec, out) = apply(Some(&rec), &op).unwrap();
+    assert_eq!(out, OpOutcome::Downgraded { fence: Fence(2) });
+    // replay after an ambiguous committed round: same fence, no re-mint, no re-write
+    let (rec2, out) = apply(Some(&rec), &op).unwrap();
+    assert_eq!(out, OpOutcome::Downgraded { fence: Fence(2) });
+    assert_eq!(rec2, rec);
+}
+
+#[test]
+fn read_release_replay_is_idempotent_via_tombstone() {
+    let rec = init();
+    let (rec, _) = acquire(&rec, 1, 10, LockKind::Read);
+    let op = Op::Release {
+        member: m(1),
+        nonce: 10,
+        expect_fence: Fence(1),
+        new_value: None,
+    };
+    let (rec, out) = apply(Some(&rec), &op).unwrap();
+    assert_eq!(out, OpOutcome::Released);
+    let (rec2, out) = apply(Some(&rec), &op).unwrap();
+    assert_eq!(out, OpOutcome::Released);
+    assert_eq!(rec2, rec);
+}

--- a/netbeam/src/sync/group/persist.rs
+++ b/netbeam/src/sync/group/persist.rs
@@ -1,0 +1,160 @@
+//! Serializable group state: a byte-exportable [`AcceptorStateStore`] so members can
+//! persist their voter state (promises + last accepted record, which embeds the
+//! protected value) and resume after a full-group shutdown.
+//!
+//! Recovery semantics (honest version):
+//! - A member restored via [`SnapshotAcceptorStore::from_bytes`] rejoins as a voter
+//!   with its promises intact — the crash-recovery requirement quorum intersection
+//!   depends on.
+//! - Once any MAJORITY of restored members is back, the last committed value is
+//!   recovered exactly (every committed round lives on a majority, and any two
+//!   majorities intersect).
+//! - A lone returning member can [`peek_value`] its last locally-accepted state
+//!   immediately — its best known snapshot, which is guaranteed current if that
+//!   member voted in the final committed round, but is otherwise possibly stale.
+//!   Lock operations still require a majority.
+//! - Durability boundary (SBIO): this store keeps state in memory and flags
+//!   dirtiness; the CONSUMER exports [`SnapshotAcceptorStore::to_bytes`] and writes
+//!   them wherever it likes. Exporting on graceful shutdown gives full-group-restart
+//!   recovery. Strict crash-recovery (power loss mid-run) requires write-BEFORE-reply
+//!   persistence: implement [`AcceptorStateStore`] directly over synchronous storage
+//!   so `save` is durable before it returns.
+
+use crate::sync::group::acceptor::{AcceptorStateStore, PersistedAcceptor};
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::record::LockRecord;
+use crate::sync::group::{Fence, LockId};
+use crate::sync::primitives::NetObject;
+use citadel_io::tokio::sync::watch;
+use citadel_io::RwLock;
+use std::collections::HashMap;
+
+/// In-memory store whose full contents round-trip through bytes, with a dirty
+/// signal so consumers can persist on their own cadence.
+pub struct SnapshotAcceptorStore {
+    states: RwLock<HashMap<LockId, PersistedAcceptor>>,
+    dirty_tx: watch::Sender<u64>,
+}
+
+impl Default for SnapshotAcceptorStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SnapshotAcceptorStore {
+    pub fn new() -> Self {
+        let (dirty_tx, _) = watch::channel(0);
+        Self {
+            states: RwLock::new(HashMap::new()),
+            dirty_tx,
+        }
+    }
+
+    /// Restores a store previously exported with [`Self::to_bytes`].
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, GroupLockError> {
+        let states = bincode::deserialize::<HashMap<LockId, PersistedAcceptor>>(bytes)?;
+        let this = Self::new();
+        *this.states.write() = states;
+        Ok(this)
+    }
+
+    /// Serializes the entire store (all locks). Route the bytes to your storage.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, GroupLockError> {
+        Ok(bincode::serialize(&*self.states.read())?)
+    }
+
+    /// A receiver that changes whenever acceptor state mutates (the value is a
+    /// monotonic save counter). Consumers persist asynchronously off this signal;
+    /// note the caveat in the module docs about async persistence vs crash safety.
+    pub fn dirty_signal(&self) -> watch::Receiver<u64> {
+        self.dirty_tx.subscribe()
+    }
+
+    /// This member's last locally-accepted record for `lock` — offline read, no
+    /// quorum. Possibly stale relative to the true committed state; see module docs.
+    pub fn peek_record(&self, lock: LockId) -> Option<LockRecord> {
+        self.states
+            .read()
+            .get(&lock)
+            .and_then(|s| s.accepted.as_ref())
+            .map(|(_, rec)| rec.clone())
+    }
+}
+
+impl AcceptorStateStore for SnapshotAcceptorStore {
+    fn load(&self, lock: LockId) -> Option<PersistedAcceptor> {
+        self.states.read().get(&lock).cloned()
+    }
+
+    fn save(&self, lock: LockId, state: &PersistedAcceptor) {
+        let _ = self.states.write().insert(lock, state.clone());
+        self.dirty_tx.send_modify(|n| *n = n.wrapping_add(1));
+    }
+}
+
+/// Deserializes this member's last known value for `lock` from a store, without a
+/// running group: `(value_version, value)`. `None` if the lock was never observed
+/// initialized locally. Staleness caveat per the module docs.
+pub fn peek_value<T: NetObject>(
+    store: &SnapshotAcceptorStore,
+    lock: LockId,
+) -> Result<Option<(Fence, T)>, GroupLockError> {
+    let Some(rec) = store.peek_record(lock) else {
+        return Ok(None);
+    };
+    let value = bincode::deserialize::<T>(&rec.value)?;
+    Ok(Some((rec.value_version, value)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::group::acceptor::Acceptor;
+    use crate::sync::group::wire::Ballot;
+    use crate::sync::group::MemberId;
+
+    fn stamped_store(value: u64) -> SnapshotAcceptorStore {
+        let store = SnapshotAcceptorStore::new();
+        let mut acc = Acceptor::default();
+        let ballot = Ballot {
+            counter: 3,
+            proposer: MemberId(1),
+        };
+        acc.on_prepare(ballot);
+        let mut rec = LockRecord::initial(bincode::serialize(&value).unwrap());
+        rec.value_version = Fence(7);
+        acc.on_accept(ballot, rec);
+        store.save(LockId(42), acc.state());
+        store
+    }
+
+    #[test]
+    fn roundtrip_preserves_promises_and_value() {
+        let store = stamped_store(1234);
+        let restored = SnapshotAcceptorStore::from_bytes(&store.to_bytes().unwrap()).unwrap();
+        // promise survives (the crash-recovery requirement)
+        let state = restored.load(LockId(42)).unwrap();
+        assert_eq!(
+            state.promised,
+            Some(Ballot {
+                counter: 3,
+                proposer: MemberId(1)
+            })
+        );
+        // value is recoverable offline
+        let (version, value) = peek_value::<u64>(&restored, LockId(42)).unwrap().unwrap();
+        assert_eq!((version, value), (Fence(7), 1234));
+        // unknown locks read as None, not an error
+        assert!(peek_value::<u64>(&restored, LockId(9)).unwrap().is_none());
+    }
+
+    #[test]
+    fn dirty_signal_fires_on_save() {
+        let store = SnapshotAcceptorStore::new();
+        let rx = store.dirty_signal();
+        let before = *rx.borrow();
+        store.save(LockId(1), &PersistedAcceptor::default());
+        assert_ne!(*rx.borrow(), before);
+    }
+}

--- a/netbeam/src/sync/group/persist_tests.rs
+++ b/netbeam/src/sync/group/persist_tests.rs
@@ -1,0 +1,126 @@
+//! Full-group-restart recovery: every member persists its voter state via
+//! `SnapshotAcceptorStore`, the whole group (mesh + facades) is torn down, and the
+//! members come back from bytes — the last committed value must survive, and a lone
+//! returning member must be able to peek it offline before any quorum forms.
+
+use crate::sync::group::integration_tests::{members, test_config};
+use crate::sync::group::persist::{peek_value, SnapshotAcceptorStore};
+use crate::sync::group::test_mesh::TestMesh;
+use crate::sync::group::{LockId, MemberId, NetGroupMutex};
+use citadel_io::tokio;
+use futures::future::join_all;
+use std::sync::Arc;
+
+async fn create_all(
+    mesh: &TestMesh,
+    all: &[MemberId],
+    lock: LockId,
+    stores: &[Arc<SnapshotAcceptorStore>],
+) -> Vec<NetGroupMutex<u64>> {
+    let futures = all.iter().zip(stores).map(|(m, store)| {
+        let cfg = test_config(all, *m);
+        let init = (*m == all[0]).then_some(100u64);
+        NetGroupMutex::<u64>::create(mesh.transport(*m), lock, cfg, store.clone(), init)
+    });
+    join_all(futures)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn full_group_restart_recovers_last_committed_value() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let lock = LockId::from_name("persist");
+
+    // ---- first incarnation: commit a value, then export every member's state ----
+    let exported: Vec<Vec<u8>> = {
+        let mesh = TestMesh::new(&all);
+        let stores: Vec<_> = (0..3)
+            .map(|_| Arc::new(SnapshotAcceptorStore::new()))
+            .collect();
+        let mutexes = create_all(&mesh, &all, lock, &stores).await;
+
+        let mut guard = mutexes[1].lock().await.unwrap();
+        *guard = 777;
+        guard.release().await.unwrap(); // committed on a majority
+        drop(mutexes); // graceful shutdown: engines unregister
+        stores.iter().map(|s| s.to_bytes().unwrap()).collect()
+        // mesh, transports, stores all drop here — "all users drop"
+    };
+
+    // ---- a lone returning member reads its last known value offline ----
+    let lone = SnapshotAcceptorStore::from_bytes(&exported[1]).unwrap();
+    let (version, value) = peek_value::<u64>(&lone, lock).unwrap().unwrap();
+    assert_eq!(
+        value, 777,
+        "lone member must see the committed value offline"
+    );
+    assert!(version.0 > 0);
+
+    // ---- full restart from bytes: the group resumes with the committed value ----
+    let mesh = TestMesh::new(&all);
+    let stores: Vec<_> = exported
+        .iter()
+        .map(|b| Arc::new(SnapshotAcceptorStore::from_bytes(b).unwrap()))
+        .collect();
+    // the owner passes Some(initial) again; Init is denied AlreadyInitialized and
+    // treated as success — the restored record wins, never the re-supplied initial
+    let mutexes = create_all(&mesh, &all, lock, &stores).await;
+
+    let mut guard = mutexes[2].lock().await.unwrap();
+    assert_eq!(
+        *guard, 777,
+        "restart must resume from the last committed value, not the initial"
+    );
+    // and the group is fully operational: mutate + hand off across members
+    *guard += 1;
+    guard.release().await.unwrap();
+    let guard = mutexes[0].lock().await.unwrap();
+    assert_eq!(*guard, 778);
+}
+
+/// Restoring only a MAJORITY (2 of 3) must also recover the committed value —
+/// the quorum-intersection guarantee, exercised through real engines.
+#[tokio::test(flavor = "multi_thread")]
+async fn majority_restart_recovers_value_without_third_member() {
+    citadel_logging::setup_log();
+    let all = members(3);
+    let lock = LockId::from_name("persist-majority");
+
+    let exported: Vec<Vec<u8>> = {
+        let mesh = TestMesh::new(&all);
+        let stores: Vec<_> = (0..3)
+            .map(|_| Arc::new(SnapshotAcceptorStore::new()))
+            .collect();
+        let mutexes = create_all(&mesh, &all, lock, &stores).await;
+        let mut guard = mutexes[0].lock().await.unwrap();
+        *guard = 555;
+        guard.release().await.unwrap();
+        drop(mutexes);
+        stores.iter().map(|s| s.to_bytes().unwrap()).collect()
+    };
+
+    // only members 1 and 2 return; member 3 stays gone (isolated from creation)
+    let mesh = TestMesh::new(&all);
+    mesh.isolate(all[2]);
+    let stores: Vec<_> = exported[..2]
+        .iter()
+        .map(|b| Arc::new(SnapshotAcceptorStore::from_bytes(b).unwrap()))
+        .collect();
+    let futures = all[..2].iter().zip(&stores).map(|(m, store)| {
+        let cfg = test_config(&all, *m);
+        let init = (*m == all[0]).then_some(100u64);
+        NetGroupMutex::<u64>::create(mesh.transport(*m), lock, cfg, store.clone(), init)
+    });
+    let mutexes: Vec<_> = join_all(futures)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let guard = mutexes[1].lock().await.unwrap();
+    assert_eq!(*guard, 555, "any majority must recover the committed value");
+}

--- a/netbeam/src/sync/group/proposer.rs
+++ b/netbeam/src/sync/group/proposer.rs
@@ -1,0 +1,250 @@
+//! CAS round driver: one [`Op`] as a CASPaxos round (Prepare/Promise → apply →
+//! Accept/Accepted) against a majority, with ballot retry; plus the `ReadHint` gather.
+
+use crate::sync::group::engine::Engine;
+use crate::sync::group::engine_util::{ms, PendingRound};
+use crate::sync::group::op_types::{Op, OpDenied, OpOutcome};
+use crate::sync::group::ops;
+use crate::sync::group::record::LockRecord;
+use crate::sync::group::wire::{Ballot, GroupMsg};
+use citadel_io::tokio::time::timeout;
+use rand::Rng;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+#[derive(Debug)]
+pub(crate) enum ProposeError {
+    /// The op's precondition failed against the linearized record.
+    Denied(OpDenied, Option<LockRecord>),
+    /// No majority reachable before the deadline.
+    QuorumUnavailable,
+}
+
+enum RoundAttempt {
+    Committed(LockRecord, OpOutcome),
+    Denied(OpDenied, Option<LockRecord>),
+    Retry,
+}
+
+impl Engine {
+    /// Runs `op` to commitment or denial, retrying until `deadline_ms` (local clock).
+    pub(crate) async fn propose(
+        &self,
+        op: &Op,
+        deadline_ms: u64,
+    ) -> Result<(LockRecord, OpOutcome), ProposeError> {
+        loop {
+            match self.round(op, deadline_ms).await {
+                RoundAttempt::Committed(rec, outcome) => {
+                    log::trace!(target: "citadel", "[GroupLock] {:?} committed {op:?} -> {outcome:?}", self.me());
+                    return Ok((rec, outcome));
+                }
+                RoundAttempt::Denied(denied, rec) => {
+                    log::trace!(target: "citadel", "[GroupLock] {:?} denied {op:?} -> {denied:?}", self.me());
+                    return Err(ProposeError::Denied(denied, rec));
+                }
+                RoundAttempt::Retry => {
+                    if self.now_ms() >= deadline_ms {
+                        return Err(ProposeError::QuorumUnavailable);
+                    }
+                    self.backoff().await;
+                }
+            }
+        }
+    }
+
+    async fn round(&self, op: &Op, deadline_ms: u64) -> RoundAttempt {
+        let counter = self.ballot_ctr.fetch_add(1, Ordering::Relaxed) + 1;
+        if counter >= u64::MAX - (1 << 16) {
+            // ballot space exhausted (only reachable under sustained attack)
+            return RoundAttempt::Retry;
+        }
+        let ballot = Ballot {
+            counter,
+            proposer: self.me(),
+        };
+        let req_id = self.next_req_id();
+        let mut pending = self.register_pending(req_id);
+        self.round_inner(op, ballot, req_id, &mut pending, deadline_ms)
+            .await
+    }
+
+    async fn round_inner(
+        &self,
+        op: &Op,
+        ballot: Ballot,
+        req_id: u64,
+        pending: &mut PendingRound<'_>,
+        deadline_ms: u64,
+    ) -> RoundAttempt {
+        let rx = &mut pending.rx;
+        let majority = self.cfg.majority();
+
+        // ---- phase 1: prepare ----
+        let prepare = GroupMsg::Prepare { ballot };
+        self.broadcast(req_id, &prepare);
+        let mut promises = 0usize;
+        let mut max_accepted: Option<(Ballot, LockRecord)> = None;
+        if let Some(GroupMsg::Promise { accepted, .. }) = self.local_vote(&prepare) {
+            promises += 1;
+            merge_accepted(&mut max_accepted, accepted);
+        } else {
+            // local voter nacked our own ballot: a higher ballot exists; retry
+            return RoundAttempt::Retry;
+        }
+        let phase_deadline = self.phase_deadline(deadline_ms);
+        while promises < majority {
+            match timeout(phase_deadline, rx.recv()).await {
+                Ok(Some((
+                    _,
+                    GroupMsg::Promise {
+                        ballot: b,
+                        accepted,
+                    },
+                ))) if b == ballot => {
+                    promises += 1;
+                    merge_accepted(&mut max_accepted, accepted);
+                }
+                Ok(Some((
+                    _,
+                    GroupMsg::PrepareNack {
+                        ballot: b,
+                        promised,
+                    },
+                ))) if b == ballot => {
+                    self.observe_ballot(promised);
+                    return RoundAttempt::Retry;
+                }
+                Ok(Some(_)) => {} // stale response from an earlier round
+                Ok(None) | Err(_) => return RoundAttempt::Retry,
+            }
+        }
+
+        // ---- apply the pure CAS ----
+        let current = max_accepted.as_ref().map(|(_, rec)| rec);
+        let (record, outcome, denied) = match ops::apply(current, op) {
+            Ok((rec, outcome)) => (rec, Some(outcome), None),
+            Err(denied) => match current {
+                // identity write: linearize the denial before reporting it
+                Some(rec) => (rec.clone(), None, Some(denied)),
+                None => return RoundAttempt::Denied(denied, None),
+            },
+        };
+
+        // ---- phase 2: accept ----
+        let accept = GroupMsg::Accept {
+            ballot,
+            record: record.clone(),
+        };
+        self.broadcast(req_id, &accept);
+        let mut acks = 0usize;
+        match self.local_vote(&accept) {
+            Some(GroupMsg::Accepted { .. }) => acks += 1,
+            _ => return RoundAttempt::Retry,
+        }
+        while acks < majority {
+            match timeout(phase_deadline, rx.recv()).await {
+                Ok(Some((_, GroupMsg::Accepted { ballot: b }))) if b == ballot => acks += 1,
+                Ok(Some((
+                    _,
+                    GroupMsg::AcceptNack {
+                        ballot: b,
+                        promised,
+                    },
+                ))) if b == ballot => {
+                    self.observe_ballot(promised);
+                    return RoundAttempt::Retry;
+                }
+                Ok(Some(_)) => {}
+                Ok(None) | Err(_) => return RoundAttempt::Retry,
+            }
+        }
+
+        match (outcome, denied) {
+            (Some(outcome), _) => RoundAttempt::Committed(record, outcome),
+            (None, Some(denied)) => RoundAttempt::Denied(denied, Some(record)),
+            (None, None) => unreachable!("apply produced neither outcome nor denial"),
+        }
+    }
+
+    /// Majority read of the highest accepted record (polling/observation hint).
+    pub(crate) async fn quorum_read(
+        &self,
+        deadline_ms: u64,
+    ) -> Result<Option<(Ballot, LockRecord)>, ProposeError> {
+        loop {
+            let req_id = self.next_req_id();
+            let mut pending = self.register_pending(req_id);
+            let result = self
+                .quorum_read_once(req_id, &mut pending, deadline_ms)
+                .await;
+            drop(pending);
+            match result {
+                Some(highest) => return Ok(highest),
+                None => {
+                    if self.now_ms() >= deadline_ms {
+                        return Err(ProposeError::QuorumUnavailable);
+                    }
+                    self.backoff().await;
+                }
+            }
+        }
+    }
+
+    async fn quorum_read_once(
+        &self,
+        req_id: u64,
+        pending: &mut PendingRound<'_>,
+        deadline_ms: u64,
+    ) -> Option<Option<(Ballot, LockRecord)>> {
+        let rx = &mut pending.rx;
+        let majority = self.cfg.majority();
+        self.broadcast(req_id, &GroupMsg::ReadHint);
+        let mut highest: Option<(Ballot, LockRecord)> = None;
+        let mut replies = 0usize;
+        if let Some(GroupMsg::ReadHintRsp { accepted }) = self.local_vote(&GroupMsg::ReadHint) {
+            replies += 1;
+            merge_accepted(&mut highest, accepted);
+        }
+        let phase_deadline = self.phase_deadline(deadline_ms);
+        while replies < majority {
+            match timeout(phase_deadline, rx.recv()).await {
+                Ok(Some((_, GroupMsg::ReadHintRsp { accepted }))) => {
+                    replies += 1;
+                    merge_accepted(&mut highest, accepted);
+                }
+                Ok(Some(_)) => {}
+                Ok(None) | Err(_) => return None,
+            }
+        }
+        Some(highest)
+    }
+
+    /// Per-phase gather budget: round timeout clipped to the op deadline.
+    fn phase_deadline(&self, deadline_ms: u64) -> Duration {
+        let remaining = deadline_ms.saturating_sub(self.now_ms());
+        self.cfg
+            .round_timeout()
+            .min(Duration::from_millis(remaining.max(1)))
+    }
+
+    /// Jittered dueling-proposer backoff: `cas_backoff_base` ±50%.
+    async fn backoff(&self) {
+        let base = ms(self.cfg.cas_backoff_base()).max(1);
+        let jittered =
+            rand::thread_rng().gen_range((base / 2).max(1)..=base.saturating_add(base / 2));
+        citadel_io::time::sleep(Duration::from_millis(jittered)).await;
+    }
+}
+
+fn merge_accepted(
+    into: &mut Option<(Ballot, LockRecord)>,
+    candidate: Option<(Ballot, LockRecord)>,
+) {
+    if let Some((b, rec)) = candidate {
+        match into {
+            Some((cur, _)) if *cur >= b => {}
+            _ => *into = Some((b, rec)),
+        }
+    }
+}

--- a/netbeam/src/sync/group/record.rs
+++ b/netbeam/src/sync/group/record.rs
@@ -1,0 +1,219 @@
+//! The replicated lock state. One `LockRecord` per lock is the single source of truth,
+//! maintained by consensus rounds; every field transition happens through
+//! [`crate::sync::group::ops::apply`].
+
+use crate::sync::group::{Fence, LockKind, MemberId};
+use serde::{Deserialize, Serialize};
+
+/// One granted holder. `(member, nonce)` identifies the requester instance
+/// (nonce is minted per acquire, so a restarted process never aliases an old grant).
+/// `lease_seq` increments on every successful renew; observers detect a live holder
+/// by watching `(fence, lease_seq)` advance.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct HolderEntry {
+    pub member: MemberId,
+    pub nonce: u64,
+    pub fence: Fence,
+    pub lease_seq: u64,
+    /// Poison consumed by this grant (write grants only). Kept in the entry so a
+    /// retried acquire/claim round reports the same `recovered` info (idempotency),
+    /// and so a cancel-races-grant dequeue can restore it.
+    pub recovered: Option<PoisonInfo>,
+}
+
+/// One queued waiter. `refresh_seq` increments on every waiter heartbeat
+/// (`Op::RefreshWait`); stagnant waiters are evicted by whoever they block.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct WaitEntry {
+    pub member: MemberId,
+    pub nonce: u64,
+    pub kind: LockKind,
+    pub refresh_seq: u64,
+}
+
+/// Current holder set: exclusive writer or a batch of concurrent readers.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+pub enum Holders {
+    #[default]
+    None,
+    Writer(HolderEntry),
+    Readers(Vec<HolderEntry>),
+}
+
+/// Set when a writer was stolen mid-critical-section; consumed (reported as
+/// `recovered = true`) by the next write grant.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct PoisonInfo {
+    pub member: MemberId,
+    pub fence: Fence,
+}
+
+/// The consensus-replicated lock register. The protected value travels inside the
+/// record (as caller-serialized bytes), so a release and its value publication commit
+/// in one atomic CAS: a crashed writer's uncommitted mutations are invisible by
+/// construction because only its own successful release could have advanced
+/// `value` / `value_version`.
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct LockRecord {
+    /// Last minted fence; a new grant's fence is `fence_counter + 1`.
+    pub fence_counter: u64,
+    /// Serialized protected value (authoritative snapshot).
+    pub value: Vec<u8>,
+    /// Fence of the write grant that committed `value` (0 = initial value).
+    pub value_version: Fence,
+    pub poisoned: Option<PoisonInfo>,
+    /// Tombstone of the last voluntary release `(member, nonce, fence)` — makes a
+    /// replayed `Release` after an ambiguous committed round idempotent.
+    pub last_released: Option<(MemberId, u64, Fence)>,
+    pub holders: Holders,
+    /// FIFO queue; arrival order == CAS serialization order.
+    pub queue: Vec<WaitEntry>,
+}
+
+impl LockRecord {
+    pub fn initial(value: Vec<u8>) -> Self {
+        Self {
+            fence_counter: 0,
+            value,
+            value_version: Fence(0),
+            poisoned: None,
+            last_released: None,
+            holders: Holders::None,
+            queue: Vec::new(),
+        }
+    }
+
+    /// Mints the next fence, advancing the counter. `None` when the counter space
+    /// is exhausted (defensive: only reachable via a hostile hand-crafted record).
+    pub(crate) fn next_fence(&mut self) -> Option<Fence> {
+        self.fence_counter = self.fence_counter.checked_add(1)?;
+        Some(Fence(self.fence_counter))
+    }
+
+    /// Structural sanity bound for wire-derived records: counters far enough from
+    /// exhaustion that protocol arithmetic cannot overflow.
+    pub(crate) fn is_sane(&self) -> bool {
+        const SLACK: u64 = 1 << 16;
+        let bound = u64::MAX - SLACK;
+        let holders_ok = match &self.holders {
+            Holders::None => true,
+            Holders::Writer(h) => h.lease_seq < bound && h.fence.0 <= self.fence_counter,
+            Holders::Readers(hs) => hs
+                .iter()
+                .all(|h| h.lease_seq < bound && h.fence.0 <= self.fence_counter),
+        };
+        self.fence_counter < bound && holders_ok && self.queue.iter().all(|w| w.refresh_seq < bound)
+    }
+
+    /// The holder entry for `(member, nonce)`, if currently granted.
+    pub fn holder(&self, member: MemberId, nonce: u64) -> Option<&HolderEntry> {
+        match &self.holders {
+            Holders::None => None,
+            Holders::Writer(h) => (h.member == member && h.nonce == nonce).then_some(h),
+            Holders::Readers(hs) => hs.iter().find(|h| h.member == member && h.nonce == nonce),
+        }
+    }
+
+    pub(crate) fn holder_mut(&mut self, member: MemberId, nonce: u64) -> Option<&mut HolderEntry> {
+        match &mut self.holders {
+            Holders::None => None,
+            Holders::Writer(h) => (h.member == member && h.nonce == nonce).then_some(h),
+            Holders::Readers(hs) => hs
+                .iter_mut()
+                .find(|h| h.member == member && h.nonce == nonce),
+        }
+    }
+
+    /// Removes the holder entry for `(member, nonce)`. Returns the removed entry and
+    /// whether it held Write mode.
+    pub(crate) fn remove_holder(
+        &mut self,
+        member: MemberId,
+        nonce: u64,
+    ) -> Option<(HolderEntry, LockKind)> {
+        match &mut self.holders {
+            Holders::None => None,
+            Holders::Writer(h) => {
+                if h.member == member && h.nonce == nonce {
+                    let h = h.clone();
+                    self.holders = Holders::None;
+                    Some((h, LockKind::Write))
+                } else {
+                    None
+                }
+            }
+            Holders::Readers(hs) => {
+                let idx = hs
+                    .iter()
+                    .position(|h| h.member == member && h.nonce == nonce)?;
+                let h = hs.remove(idx);
+                if hs.is_empty() {
+                    self.holders = Holders::None;
+                }
+                Some((h, LockKind::Read))
+            }
+        }
+    }
+
+    pub fn wait_entry(&self, member: MemberId, nonce: u64) -> Option<(usize, &WaitEntry)> {
+        self.queue
+            .iter()
+            .enumerate()
+            .find(|(_, w)| w.member == member && w.nonce == nonce)
+    }
+
+    pub(crate) fn remove_wait_entry(&mut self, member: MemberId, nonce: u64) -> Option<WaitEntry> {
+        let idx = self
+            .queue
+            .iter()
+            .position(|w| w.member == member && w.nonce == nonce)?;
+        Some(self.queue.remove(idx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn holder(member: u64, nonce: u64) -> HolderEntry {
+        HolderEntry {
+            member: MemberId(member),
+            nonce,
+            fence: Fence(1),
+            lease_seq: 0,
+            recovered: None,
+        }
+    }
+
+    #[test]
+    fn fence_minting_is_strictly_monotonic() {
+        let mut r = LockRecord::initial(vec![]);
+        let a = r.next_fence().unwrap();
+        let b = r.next_fence().unwrap();
+        assert!(b > a);
+        assert_eq!(r.fence_counter, 2);
+    }
+
+    #[test]
+    fn remove_last_reader_collapses_to_none() {
+        let mut r = LockRecord::initial(vec![]);
+        r.holders = Holders::Readers(vec![holder(1, 10), holder(2, 20)]);
+        assert_eq!(
+            r.remove_holder(MemberId(1), 10).map(|(_, k)| k),
+            Some(LockKind::Read)
+        );
+        assert!(matches!(&r.holders, Holders::Readers(hs) if hs.len() == 1));
+        r.remove_holder(MemberId(2), 20).unwrap();
+        assert_eq!(r.holders, Holders::None);
+        assert!(r.remove_holder(MemberId(2), 20).is_none());
+    }
+
+    #[test]
+    fn holder_lookup_requires_matching_nonce() {
+        let mut r = LockRecord::initial(vec![]);
+        r.holders = Holders::Writer(holder(1, 10));
+        assert!(r.holder(MemberId(1), 10).is_some());
+        assert!(r.holder(MemberId(1), 11).is_none());
+        assert!(r.remove_holder(MemberId(1), 11).is_none());
+    }
+}

--- a/netbeam/src/sync/group/rwlock.rs
+++ b/netbeam/src/sync/group/rwlock.rs
@@ -1,0 +1,107 @@
+//! N-node fault-tolerant read-write lock with tokio-style write-preferring FIFO
+//! semantics: readers are admitted in concurrent batches between writers; once a
+//! writer queues, later readers wait behind it (no writer starvation). There is no
+//! read→write upgrade (two upgrading readers deadlock by construction); write→read
+//! [`NetGroupWriteGuard::downgrade`] is supported.
+
+use crate::sync::group::acceptor::AcceptorStateStore;
+use crate::sync::group::config::GroupLockConfig;
+use crate::sync::group::engine::Engine;
+use crate::sync::group::error::GroupLockError;
+use crate::sync::group::guard::{NetGroupReadGuard, NetGroupWriteGuard};
+use crate::sync::group::transport::GroupTransport;
+use crate::sync::group::{LockId, LockKind};
+use crate::sync::primitives::NetObject;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub struct NetGroupRwLock<T: NetObject> {
+    engine: Arc<Engine>,
+    _pd: PhantomData<fn() -> T>,
+}
+
+impl<T: NetObject> NetGroupRwLock<T> {
+    /// Joins (and on the owner, initializes) the distributed rwlock `lock_id`.
+    /// Every member must call this; exactly the `initial_value_owner` passes `Some`.
+    pub async fn create(
+        transport: Arc<GroupTransport>,
+        lock_id: LockId,
+        cfg: GroupLockConfig,
+        store: Arc<dyn AcceptorStateStore>,
+        initial: Option<T>,
+    ) -> Result<Self, GroupLockError> {
+        let engine =
+            crate::sync::group::create::create_engine(transport, lock_id, cfg, store, initial)
+                .await?;
+        Ok(Self {
+            engine,
+            _pd: PhantomData,
+        })
+    }
+
+    /// Shared access; batches with concurrent readers group-wide.
+    pub async fn read(&self) -> Result<NetGroupReadGuard<T>, GroupLockError> {
+        self.read_with_timeout(self.engine.cfg.acquire_timeout())
+            .await
+    }
+
+    pub async fn read_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<NetGroupReadGuard<T>, GroupLockError> {
+        let grant = self.engine.acquire(LockKind::Read, false, timeout).await?;
+        NetGroupReadGuard::from_grant(self.engine.clone(), grant)
+    }
+
+    /// Exclusive access.
+    pub async fn write(&self) -> Result<NetGroupWriteGuard<T>, GroupLockError> {
+        self.write_with_timeout(self.engine.cfg.acquire_timeout())
+            .await
+    }
+
+    pub async fn write_with_timeout(
+        &self,
+        timeout: Duration,
+    ) -> Result<NetGroupWriteGuard<T>, GroupLockError> {
+        let grant = self.engine.acquire(LockKind::Write, false, timeout).await?;
+        NetGroupWriteGuard::from_grant(self.engine.clone(), grant)
+    }
+
+    /// Single-round attempts: `Ok(None)` when contended.
+    pub async fn try_read(&self) -> Result<Option<NetGroupReadGuard<T>>, GroupLockError> {
+        match self
+            .engine
+            .acquire(LockKind::Read, true, self.engine.cfg.round_timeout())
+            .await
+        {
+            Ok(grant) => Ok(Some(NetGroupReadGuard::from_grant(
+                self.engine.clone(),
+                grant,
+            )?)),
+            Err(GroupLockError::WouldBlock) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub async fn try_write(&self) -> Result<Option<NetGroupWriteGuard<T>>, GroupLockError> {
+        match self
+            .engine
+            .acquire(LockKind::Write, true, self.engine.cfg.round_timeout())
+            .await
+        {
+            Ok(grant) => Ok(Some(NetGroupWriteGuard::from_grant(
+                self.engine.clone(),
+                grant,
+            )?)),
+            Err(GroupLockError::WouldBlock) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl<T: NetObject> Drop for NetGroupRwLock<T> {
+    fn drop(&mut self) {
+        self.engine.shutdown();
+    }
+}

--- a/netbeam/src/sync/group/sim_tests.rs
+++ b/netbeam/src/sync/group/sim_tests.rs
@@ -1,0 +1,250 @@
+//! Deterministic seeded protocol simulator: N pure acceptors + a synchronous CASPaxos
+//! proposer, inline xorshift64 RNG (no I/O, no clocks). Invariants panic with the seed.
+use super::acceptor::{AcceptReply, Acceptor, PrepareReply};
+use super::op_types::{Op, OpDenied, OpOutcome};
+use super::ops::apply;
+use super::record::{HolderEntry, Holders, LockRecord};
+use super::wire::Ballot;
+use super::{admission, Fence, LockKind, MemberId};
+use std::collections::HashMap;
+
+const N: usize = 5;
+const QUORUM: usize = N / 2 + 1;
+
+type Rec = LockRecord;
+type RoundResult = Result<(Rec, OpOutcome), OpDenied>;
+
+#[derive(Default)]
+struct Belief {
+    held: Option<(u64, LockKind, Fence, u64)>, // (nonce, kind, fence, lease_seq)
+    queued: Option<(u64, LockKind)>,
+}
+impl Belief {
+    fn grant(&mut self, nonce: u64, kind: LockKind, fence: Fence) {
+        self.queued = None;
+        self.held = Some((nonce, kind, fence, 0));
+    }
+}
+fn holders(rec: &Rec) -> &[HolderEntry] {
+    match &rec.holders {
+        Holders::None => &[],
+        Holders::Writer(h) => std::slice::from_ref(h),
+        Holders::Readers(hs) => hs,
+    }
+}
+
+#[derive(Default)]
+struct Sim {
+    seed: u64,
+    step: usize,
+    rng: u64,
+    acceptors: Vec<Acceptor>,
+    beliefs: Vec<Belief>,
+    reachable: [bool; N],
+    counter: u64,
+    next_nonce: u64,
+    max_fence: u64,
+    max_vv: u64,
+    committed: HashMap<Ballot, Rec>,
+}
+
+impl Sim {
+    #[allow(clippy::field_reassign_with_default)]
+    fn new(seed: u64) -> Self {
+        let mut s = Self::default();
+        (s.seed, s.rng) = (seed, seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+        s.acceptors = vec![Acceptor::default(); N];
+        s.beliefs = (0..N).map(|_| Belief::default()).collect();
+        s.reachable = [true; N];
+        s
+    }
+
+    fn rand(&mut self) -> u64 {
+        self.rng ^= self.rng << 13;
+        self.rng ^= self.rng >> 7;
+        self.rng ^= self.rng << 17;
+        self.rng
+    }
+
+    /// One synchronous CASPaxos round against the reachable subset: majority promises,
+    /// apply on the max-ballot promised record, majority acks. `None` = failed round.
+    fn propose(&mut self, proposer: MemberId, op: &Op) -> Option<RoundResult> {
+        let reach = self.reachable;
+        reach[proposer.0 as usize].then_some(())?;
+        self.counter += 1;
+        let counter = self.counter;
+        let ballot = Ballot { counter, proposer };
+        let (mut votes, mut promised) = (0, Vec::new());
+        for i in (0..N).filter(|i| reach[*i]) {
+            if let PrepareReply::Promise { accepted } = self.acceptors[i].on_prepare(ballot) {
+                votes += 1;
+                promised.extend(accepted);
+            }
+        }
+        (votes >= QUORUM).then_some(())?;
+        let base = promised.into_iter().max_by_key(|(b, _)| *b).map(|(_, r)| r);
+        let (rec, res) = match apply(base.as_ref(), op) {
+            Ok((rec, out)) => (rec, Ok(out)),
+            Err(d) => (base.clone()?, Err(d)), // identity write linearizes denials
+        };
+        let mut acks = 0;
+        for i in (0..N).filter(|i| reach[*i]) {
+            let reply = self.acceptors[i].on_accept(ballot, rec.clone());
+            acks += matches!(reply, AcceptReply::Accepted) as usize;
+        }
+        (acks >= QUORUM).then_some(())?; // ambiguous rounds may still commit later
+        if let Some(prev) = self.committed.insert(ballot, rec.clone()) {
+            assert_eq!(&prev, &rec, "seed {}: ballot reuse", self.seed);
+        }
+        self.check(base.as_ref(), op, &rec, res.as_ref().ok());
+        Some(res.map(|out| (rec, out)))
+    }
+
+    /// Safety invariants over the committed transition `pre -> new` caused by `op`.
+    fn check(&mut self, pre: Option<&Rec>, op: &Op, new: &Rec, o: Option<&OpOutcome>) {
+        let c = format!("seed={} step={}", self.seed, self.step);
+        let mut ids: Vec<_> = new.queue.iter().map(|w| (w.member, w.nonce)).collect();
+        ids.extend(holders(new).iter().map(|h| (h.member, h.nonce)));
+        let rdrs_ok = !matches!(&new.holders, Holders::Readers(hs) if hs.is_empty());
+        assert!(rdrs_ok, "{c}: empty Readers");
+        ids.sort_unstable();
+        assert!(ids.windows(2).all(|w| w[0] != w[1]), "{c}: dup entry");
+        let Some(out) = o else { return }; // denial = identity write: structure only
+        if let OpOutcome::Granted { fence, .. } | OpOutcome::Downgraded { fence } = out {
+            if pre != Some(new) {
+                assert!(fence.0 > self.max_fence, "{c}: stale fence {fence:?}");
+                self.max_fence = fence.0;
+            }
+        }
+        let bvv = pre.map_or(0, |r| r.value_version.0);
+        if new.value_version.0 != bvv {
+            let ok = matches!(op, Op::Release { new_value: Some(_), expect_fence, .. }
+                | Op::Downgrade { new_value: Some(_), expect_fence, .. }
+                if new.value_version == *expect_fence);
+            assert!(ok && new.value_version.0 > bvv, "{c}: bad vv via {op:?}");
+        }
+        assert!(new.value_version.0 >= self.max_vv, "{c}: vv regressed");
+        self.max_vv = new.value_version.0;
+        if let (Op::ClaimQueued { member, nonce }, OpOutcome::Granted { .. }) = (op, out) {
+            if let Some(b) = pre.filter(|b| b.wait_entry(*member, *nonce).is_some()) {
+                assert!(admission::is_admissible(b, *member, *nonce), "{c}: fifo");
+            }
+        }
+        match (pre.and_then(|r| r.poisoned.as_ref()), &new.poisoned) {
+            (None, Some(_)) => {
+                let steal = matches!(op, Op::Steal { target, target_nonce, .. }
+                    if matches!(pre.map(|r| &r.holders), Some(Holders::Writer(h))
+                        if h.member == *target && h.nonce == *target_nonce));
+                let deq = matches!(out, OpOutcome::Dequeued { was_granted: true });
+                assert!(steal || deq, "{c}: poison set by {op:?}");
+            }
+            (Some(p), None) => assert!(
+                matches!(out, OpOutcome::Granted { recovered: Some(r), .. } if r == p),
+                "{c}: poison cleared by {op:?}"
+            ),
+            (Some(a), Some(b)) => assert_eq!(a, b, "{c}: poison replaced by {op:?}"),
+            _ => {}
+        }
+    }
+
+    #[rustfmt::skip] // dense op-construction table reads better unwrapped
+    fn gen_op(&mut self, m: usize) -> Op {
+        let member = MemberId(m as u64);
+        if let Some((nonce, kind, expect_fence, expect_lease_seq)) = self.beliefs[m].held {
+            let w = kind == LockKind::Write;
+            let new_value = (w && self.rand() & 1 == 0).then(|| vec![m as u8]);
+            return match self.rand() % 6 {
+                0 | 1 => Op::Renew { member, nonce, expect_fence, expect_lease_seq },
+                2 if w => Op::Downgrade { member, nonce, expect_fence, new_value },
+                _ => Op::Release { member, nonce, expect_fence, new_value },
+            };
+        }
+        if let Some((nonce, _)) = self.beliefs[m].queued {
+            return match self.rand() % 6 {
+                0 => Op::RefreshWait { member, nonce },
+                1 => Op::Dequeue { member, nonce },
+                _ => Op::ClaimQueued { member, nonce },
+            };
+        }
+        if let Some(op) = self.rand().is_multiple_of(4).then(|| self.disrupt(m)).flatten() {
+            return op;
+        }
+        self.next_nonce += 1;
+        let kind = [LockKind::Read, LockKind::Write][(self.rand() & 1) as usize];
+        let (nonce, no_enqueue) = (self.next_nonce, self.rand().is_multiple_of(4));
+        Op::AcquireOrEnqueue { member, nonce, kind, no_enqueue }
+    }
+
+    /// Steal a holder / evict a waiter from the local voter's accepted-state hint.
+    #[rustfmt::skip]
+    fn disrupt(&mut self, m: usize) -> Option<Op> {
+        let (_, seen) = self.acceptors[m].read_hint()?;
+        if self.rand() & 1 == 0 {
+            let hs = holders(&seen);
+            let h = hs.get((self.rand() % hs.len().max(1) as u64) as usize)?;
+            let (target, target_nonce) = (h.member, h.nonce);
+            let (f, s) = (h.fence, h.lease_seq);
+            Some(Op::Steal { target, target_nonce, expect_fence: f, expect_lease_seq: s })
+        } else {
+            let w = seen.queue.get((self.rand() % seen.queue.len().max(1) as u64) as usize)?;
+            let (target, target_nonce) = (w.member, w.nonce);
+            Some(Op::EvictWaiter { target, target_nonce, expect_refresh_seq: w.refresh_seq })
+        }
+    }
+
+    fn absorb(&mut self, m: usize, op: &Op, res: &Option<RoundResult>) {
+        use super::op_types::Op::{AcquireOrEnqueue as Acq, ClaimQueued as Claim, *};
+        use super::op_types::OpOutcome::{Downgraded as D, Granted as G, *};
+        use super::LockKind::Read;
+        let b = &mut self.beliefs[m];
+        let out = match res {
+            Some(Ok((_, out))) => out,
+            Some(Err(OpDenied::NotHolder)) => return b.held = None, // stolen: forget it
+            Some(Err(OpDenied::NotQueued)) if matches!(op, Claim { .. } | Dequeue { .. }) => {
+                return b.queued = None; // evicted: forget the wait entry
+            }
+            _ => return, // failed round or benign denial: no new knowledge
+        };
+        match (op, out) {
+            (Acq { nonce, kind, .. }, G { fence, .. }) => b.grant(*nonce, *kind, *fence),
+            (Acq { nonce, kind, .. }, Enqueued { .. }) => b.queued = Some((*nonce, *kind)),
+            (Claim { nonce, .. }, G { fence, .. }) => {
+                let k = b.queued.take().map_or(LockKind::Write, |(_, k)| k);
+                b.grant(*nonce, k, *fence);
+            }
+            (Renew { .. }, Renewed { lease_seq }) => b.held.as_mut().unwrap().3 = *lease_seq,
+            (Release { .. }, Released) => b.held = None,
+            (Downgrade { nonce, .. }, D { fence, .. }) => b.grant(*nonce, Read, *fence),
+            (Dequeue { .. }, Dequeued { .. }) => (b.held, b.queued) = (None, None),
+            _ => {}
+        }
+    }
+
+    fn run(mut self, steps: usize) {
+        let init = self.propose(MemberId(0), &Op::Init { value: vec![0] });
+        let ok = matches!(init, Some(Ok((_, OpOutcome::Initialized))));
+        assert!(ok, "seed {}: init round must commit", self.seed);
+        for step in 1..=steps {
+            self.step = step;
+            let m = (self.rand() % N as u64) as usize;
+            if self.rand() % 10 < 2 {
+                self.reachable[m] = !self.reachable[m]; // partition toggle
+                continue;
+            }
+            let op = self.gen_op(m);
+            let res = self.propose(MemberId(m as u64), &op);
+            self.absorb(m, &op, &res);
+        }
+    }
+}
+
+#[test]
+fn seeded_protocol_simulation() {
+    (1..=200).for_each(|seed| Sim::new(seed).run(300));
+}
+
+#[test]
+#[ignore = "stress schedule (~10s): cargo test -p netbeam sim_tests -- --ignored"]
+fn seeded_protocol_simulation_stress() {
+    (1..=2000).for_each(|seed| Sim::new(seed).run(3000));
+}

--- a/netbeam/src/sync/group/test_mesh.rs
+++ b/netbeam/src/sync/group/test_mesh.rs
@@ -1,0 +1,150 @@
+//! In-memory full-mesh builder for tests and examples: n members wired with
+//! severable in-memory pipes, enabling deterministic fault injection (partitions,
+//! isolated members ≈ crashed members) without sockets.
+
+use crate::reliable_conn::ReliableOrderedStreamToTarget;
+use crate::sync::group::transport::GroupTransport;
+use crate::sync::group::MemberId;
+use async_trait::async_trait;
+use bytes::Bytes;
+use citadel_io::tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use citadel_io::tokio::sync::Mutex;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// One direction of an in-memory link. `severed` is shared by both directions of
+/// the pair: while set, sends fail (as a broken transport would) — in-flight
+/// messages already queued still deliver, mimicking real partition onset.
+pub struct InMemoryPipe {
+    tx: UnboundedSender<Vec<u8>>,
+    rx: Mutex<UnboundedReceiver<Vec<u8>>>,
+    severed: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl ReliableOrderedStreamToTarget for InMemoryPipe {
+    async fn send_to_peer(&self, input: &[u8]) -> std::io::Result<()> {
+        if self.severed.load(Ordering::Acquire) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "link severed",
+            ));
+        }
+        self.tx.send(input.to_vec()).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "peer receiver dropped")
+        })
+    }
+
+    async fn recv(&self) -> std::io::Result<Bytes> {
+        self.rx
+            .lock()
+            .await
+            .recv()
+            .await
+            .map(Bytes::from)
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe closed"))
+    }
+}
+
+/// A full mesh of `n` members with per-pair severable links.
+pub struct TestMesh {
+    transports: HashMap<MemberId, Arc<GroupTransport>>,
+    links: HashMap<(MemberId, MemberId), Arc<AtomicBool>>,
+}
+
+impl TestMesh {
+    pub fn new(member_ids: &[MemberId]) -> Self {
+        let mut endpoints: HashMap<
+            MemberId,
+            HashMap<MemberId, Arc<dyn ReliableOrderedStreamToTarget + 'static>>,
+        > = member_ids.iter().map(|m| (*m, HashMap::new())).collect();
+        let mut links = HashMap::new();
+
+        for (i, a) in member_ids.iter().enumerate() {
+            for b in &member_ids[i + 1..] {
+                let severed = Arc::new(AtomicBool::new(false));
+                let (tx_ab, rx_ab) = unbounded_channel();
+                let (tx_ba, rx_ba) = unbounded_channel();
+                let pipe_a = InMemoryPipe {
+                    tx: tx_ab,
+                    rx: Mutex::new(rx_ba),
+                    severed: severed.clone(),
+                };
+                let pipe_b = InMemoryPipe {
+                    tx: tx_ba,
+                    rx: Mutex::new(rx_ab),
+                    severed: severed.clone(),
+                };
+                endpoints.get_mut(a).unwrap().insert(*b, Arc::new(pipe_a));
+                endpoints.get_mut(b).unwrap().insert(*a, Arc::new(pipe_b));
+                links.insert(Self::key(*a, *b), severed);
+            }
+        }
+
+        let transports = endpoints
+            .into_iter()
+            .map(|(id, peers)| (id, GroupTransport::new(id, peers)))
+            .collect();
+        Self { transports, links }
+    }
+
+    fn key(a: MemberId, b: MemberId) -> (MemberId, MemberId) {
+        if a <= b {
+            (a, b)
+        } else {
+            (b, a)
+        }
+    }
+
+    pub fn transport(&self, id: MemberId) -> Arc<GroupTransport> {
+        self.transports
+            .get(&id)
+            .expect("member not in mesh")
+            .clone()
+    }
+
+    /// Sets/clears the severed state of the `a<->b` link (both directions).
+    pub fn set_link_severed(&self, a: MemberId, b: MemberId, severed: bool) {
+        self.links
+            .get(&Self::key(a, b))
+            .expect("link not in mesh")
+            .store(severed, Ordering::Release);
+    }
+
+    /// Severs every link touching `id`. An isolated member cannot renew or refresh,
+    /// so from the group's perspective it is indistinguishable from a crash — the
+    /// standard way to "kill" a member in fault-injection tests.
+    pub fn isolate(&self, id: MemberId) {
+        for (pair, flag) in &self.links {
+            if pair.0 == id || pair.1 == id {
+                flag.store(true, Ordering::Release);
+            }
+        }
+    }
+
+    /// Heals every link touching `id` (partition recovery).
+    pub fn rejoin(&self, id: MemberId) {
+        for (pair, flag) in &self.links {
+            if pair.0 == id || pair.1 == id {
+                flag.store(false, Ordering::Release);
+            }
+        }
+    }
+
+    /// Partitions the mesh into two sides: every cross-side link is severed.
+    pub fn partition(&self, side_a: &[MemberId], side_b: &[MemberId]) {
+        for a in side_a {
+            for b in side_b {
+                self.set_link_severed(*a, *b, true);
+            }
+        }
+    }
+
+    /// Heals all links in the mesh.
+    pub fn heal_all(&self) {
+        for flag in self.links.values() {
+            flag.store(false, Ordering::Release);
+        }
+    }
+}

--- a/netbeam/src/sync/group/transport.rs
+++ b/netbeam/src/sync/group/transport.rs
@@ -1,0 +1,186 @@
+//! Group mesh transport: routes [`GroupPacket`]s between the local member and its
+//! peers over caller-supplied point-to-point reliable ordered streams. netbeam never
+//! dials; the consumer wires the full mesh (and may heal it via
+//! [`GroupTransport::replace_peer_stream`] after a reconnect).
+//!
+//! This layer performs no protocol decisions: it serializes, demultiplexes by
+//! [`LockId`], and drops packets whose config digest mismatches the registered lock.
+
+use crate::reliable_conn::ReliableOrderedStreamToTarget;
+use crate::sync::group::wire::GroupPacket;
+use crate::sync::group::{LockId, MemberId};
+use citadel_io::tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use citadel_io::tokio::sync::watch;
+use citadel_io::RwLock;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+struct PeerConn {
+    conn: Arc<dyn ReliableOrderedStreamToTarget + 'static>,
+    generation: u64,
+    /// Dropped/renewed when the peer stream is replaced; the recv loop selects on
+    /// it so a superseded or shut-down loop terminates instead of parking forever.
+    stop_tx: watch::Sender<bool>,
+}
+
+struct LockChannel {
+    tx: UnboundedSender<GroupPacket>,
+    config_digest: u64,
+}
+
+pub struct GroupTransport {
+    local_id: MemberId,
+    peers: RwLock<HashMap<MemberId, PeerConn>>,
+    locks: RwLock<HashMap<LockId, LockChannel>>,
+    generation_ctr: AtomicU64,
+}
+
+impl GroupTransport {
+    /// `peers` must contain one reliable ordered stream per remote member of every
+    /// group this transport will serve. Spawns one receive loop per peer.
+    pub fn new(
+        local_id: MemberId,
+        peers: HashMap<MemberId, Arc<dyn ReliableOrderedStreamToTarget + 'static>>,
+    ) -> Arc<Self> {
+        let this = Arc::new(Self {
+            local_id,
+            peers: RwLock::new(HashMap::new()),
+            locks: RwLock::new(HashMap::new()),
+            generation_ctr: AtomicU64::new(0),
+        });
+        for (id, conn) in peers {
+            this.install_peer(id, conn);
+        }
+        this
+    }
+
+    pub fn local_id(&self) -> MemberId {
+        self.local_id
+    }
+
+    /// Replaces (or installs) the stream to `peer` — the healing hook for members
+    /// that reconnect after a network partition. The old receive loop retires on its
+    /// next packet (generation check) or stream error.
+    pub fn replace_peer_stream(
+        self: &Arc<Self>,
+        peer: MemberId,
+        conn: Arc<dyn ReliableOrderedStreamToTarget + 'static>,
+    ) {
+        self.install_peer(peer, conn);
+    }
+
+    fn install_peer(
+        self: &Arc<Self>,
+        peer: MemberId,
+        conn: Arc<dyn ReliableOrderedStreamToTarget + 'static>,
+    ) {
+        let generation = self.generation_ctr.fetch_add(1, Ordering::Relaxed) + 1;
+        let (stop_tx, mut stop_rx) = watch::channel(false);
+        let previous = self.peers.write().insert(
+            peer,
+            PeerConn {
+                conn: conn.clone(),
+                generation,
+                stop_tx,
+            },
+        );
+        if let Some(previous) = previous {
+            // wake the superseded loop even if its stream never yields again
+            let _ = previous.stop_tx.send_replace(true);
+        }
+        let this = self.clone();
+        citadel_io::spawn(async move {
+            loop {
+                let bytes = citadel_io::tokio::select! {
+                    r = conn.recv() => match r {
+                        Ok(b) => b,
+                        Err(err) => {
+                            log::trace!(target: "citadel", "[GroupTransport] recv loop for peer {peer:?} ended: {err:?}");
+                            break;
+                        }
+                    },
+                    _ = stop_rx.changed() => break,
+                };
+                // belt-and-braces: never route a packet read under a stale generation
+                let current = this.peers.read().get(&peer).map(|p| p.generation);
+                if current != Some(generation) {
+                    break;
+                }
+                match bincode::deserialize::<GroupPacket>(&bytes) {
+                    Ok(packet) => this.route(peer, packet),
+                    Err(err) => {
+                        log::warn!(target: "citadel", "[GroupTransport] malformed packet from {peer:?}: {err}")
+                    }
+                }
+            }
+        });
+    }
+
+    /// Stops every peer receive loop and drops the stream handles. Call when the
+    /// mesh is done (engines unregister their locks independently); without this,
+    /// the loop tasks hold `Arc<GroupTransport>` + stream references alive.
+    pub fn shutdown(&self) {
+        let mut peers = self.peers.write();
+        for (_, peer) in peers.drain() {
+            let _ = peer.stop_tx.send_replace(true);
+        }
+    }
+
+    fn route(&self, peer: MemberId, packet: GroupPacket) {
+        if packet.from != peer {
+            log::warn!(target: "citadel", "[GroupTransport] origin mismatch: stream {peer:?} claimed {:?}; dropping", packet.from);
+            return;
+        }
+        let locks = self.locks.read();
+        let Some(channel) = locks.get(&packet.lock_id) else {
+            log::trace!(target: "citadel", "[GroupTransport] no lock registered for {:?}; dropping", packet.lock_id);
+            return;
+        };
+        if channel.config_digest != packet.config_digest {
+            log::warn!(target: "citadel", "[GroupTransport] config digest mismatch from {peer:?} on {:?}; dropping (split config?)", packet.lock_id);
+            return;
+        }
+        let _ = channel.tx.send(packet);
+    }
+
+    /// Registers a lock engine's inbox. Fails if the id is already registered.
+    pub(crate) fn register_lock(
+        &self,
+        lock_id: LockId,
+        config_digest: u64,
+    ) -> Option<UnboundedReceiver<GroupPacket>> {
+        let mut locks = self.locks.write();
+        if locks.contains_key(&lock_id) {
+            return None;
+        }
+        let (tx, rx) = unbounded_channel();
+        locks.insert(lock_id, LockChannel { tx, config_digest });
+        Some(rx)
+    }
+
+    pub(crate) fn unregister_lock(&self, lock_id: LockId) {
+        let _ = self.locks.write().remove(&lock_id);
+    }
+
+    /// Best-effort fire-and-forget send. Failures are logged (a dead peer simply
+    /// contributes no vote; safety never depends on delivery).
+    pub(crate) fn send_to(&self, peer: MemberId, packet: &GroupPacket) {
+        let Some(conn) = self.peers.read().get(&peer).map(|p| p.conn.clone()) else {
+            log::trace!(target: "citadel", "[GroupTransport] no stream to {peer:?}");
+            return;
+        };
+        let bytes = match bincode::serialize(packet) {
+            Ok(b) => b,
+            Err(err) => {
+                log::warn!(target: "citadel", "[GroupTransport] serialize failure: {err}");
+                return;
+            }
+        };
+        citadel_io::spawn(async move {
+            if let Err(err) = conn.send_to_peer(&bytes).await {
+                log::trace!(target: "citadel", "[GroupTransport] send to {peer:?} failed: {err:?}");
+            }
+        });
+    }
+}

--- a/netbeam/src/sync/group/wire.rs
+++ b/netbeam/src/sync/group/wire.rs
@@ -1,0 +1,119 @@
+//! Wire format for group lock traffic. One [`GroupPacket`] envelope per message,
+//! bincode-encoded over the caller-supplied per-pair reliable ordered streams.
+//! Per-pair FIFO gives no cross-member order, so nothing here relies on arrival
+//! order: consensus rounds are correlated by `req_id` and ordered by [`Ballot`].
+
+use crate::sync::group::record::LockRecord;
+use crate::sync::group::{LockId, MemberId};
+use serde::{Deserialize, Serialize};
+
+/// Proposal number. The `Ord` derive yields the lexicographic (counter, proposer)
+/// order — exactly the Lamport (timestamp, member id) total-order tiebreak.
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Ballot {
+    pub counter: u64,
+    pub proposer: MemberId,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum GroupMsg {
+    // ---- consensus (CAS rounds) ----
+    Prepare {
+        ballot: Ballot,
+    },
+    Promise {
+        ballot: Ballot,
+        accepted: Option<(Ballot, LockRecord)>,
+    },
+    PrepareNack {
+        ballot: Ballot,
+        promised: Ballot,
+    },
+    Accept {
+        ballot: Ballot,
+        record: LockRecord,
+    },
+    Accepted {
+        ballot: Ballot,
+    },
+    AcceptNack {
+        ballot: Ballot,
+        promised: Ballot,
+    },
+    // ---- hints (never gate safety) ----
+    /// Cheap read of a voter's highest accepted state; the proposer assembles a
+    /// majority of these for wait-loop polling and janitor observation snapshots.
+    ReadHint,
+    ReadHintRsp {
+        accepted: Option<(Ballot, LockRecord)>,
+    },
+    /// Best-effort wake sent by a releaser to members whose queue entries may have
+    /// become admissible. Loss is tolerated (waiter_poll_interval backstop).
+    Nudge,
+}
+
+impl GroupMsg {
+    /// Whether this message is a request serviced by the voter task (vs a response
+    /// routed back to a pending proposer round).
+    pub fn is_voter_request(&self) -> bool {
+        matches!(
+            self,
+            Self::Prepare { .. } | Self::Accept { .. } | Self::ReadHint
+        )
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct GroupPacket {
+    pub lock_id: LockId,
+    pub from: MemberId,
+    /// Correlates responses with the proposer round (or hint gather) that issued the
+    /// request. Voter requests echo the id back in the response.
+    pub req_id: u64,
+    /// Digest of the shared [`crate::sync::group::GroupLockConfig`]; packets with a
+    /// mismatched digest are dropped and logged (fail-fast on split configs).
+    pub config_digest: u64,
+    pub msg: GroupMsg,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ballot_order_is_counter_then_member() {
+        let a = Ballot {
+            counter: 1,
+            proposer: MemberId(9),
+        };
+        let b = Ballot {
+            counter: 2,
+            proposer: MemberId(1),
+        };
+        let c = Ballot {
+            counter: 2,
+            proposer: MemberId(2),
+        };
+        assert!(a < b && b < c);
+    }
+
+    #[test]
+    fn roundtrip_bincode() {
+        let pkt = GroupPacket {
+            lock_id: LockId(7),
+            from: MemberId(3),
+            req_id: 42,
+            config_digest: 99,
+            msg: GroupMsg::Prepare {
+                ballot: Ballot {
+                    counter: 5,
+                    proposer: MemberId(3),
+                },
+            },
+        };
+        let bytes = bincode::serialize(&pkt).unwrap();
+        let back = bincode::deserialize::<GroupPacket>(&bytes).unwrap();
+        assert_eq!(back.lock_id, pkt.lock_id);
+        assert!(matches!(back.msg, GroupMsg::Prepare { ballot } if ballot.counter == 5));
+    }
+}

--- a/netbeam/src/sync/mod.rs
+++ b/netbeam/src/sync/mod.rs
@@ -32,6 +32,7 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod group;
 pub mod operations;
 pub mod primitives;
 

--- a/netbeam/src/sync/operations/net_select_ok.rs
+++ b/netbeam/src/sync/operations/net_select_ok.rs
@@ -178,7 +178,7 @@ where
         loop {
             log::trace!(target: "citadel", "{local_node_type:?} awaiting ...");
             let received_remote_state = conn.recv_serialized::<State>().await?;
-            log::trace!(target: "citadel", "{:?} RECV'd {:?}", local_node_type, &received_remote_state);
+            log::trace!(target: "citadel", "{:?} RECV'd {:?}", local_node_type, received_remote_state);
             let mut lock = local_state_ref.lock().await;
             let local_state_info = lock.ret_value.as_ref().map(|r| r.is_ok());
             let adjacent_success = received_remote_state.implies_remote_success();

--- a/netbeam/src/sync/primitives/net_mutex.rs
+++ b/netbeam/src/sync/primitives/net_mutex.rs
@@ -306,7 +306,7 @@ async fn net_mutex_drop_code<T: NetObject, S: Subscribable + 'static>(
 
     loop {
         let packet = conn.recv_serialized::<UpdatePacket>().await?;
-        log::trace!(target: "citadel", "[NetMutex] [Drop Code] RECV {:?} on {:?}", &packet, conn.node_type());
+        log::trace!(target: "citadel", "[NetMutex] [Drop Code] RECV {:?} on {:?}", packet, conn.node_type());
         match packet {
             UpdatePacket::ReleasedVerified => {
                 log::trace!(target: "citadel", "[NetMutex] [Drop Code] Release has been verified for {:?}. Adjacent node updated; will drop local lock. Adjacent trying to acquire? {adjacent_trying_to_acquire}", conn.node_type());
@@ -384,7 +384,7 @@ async fn net_mutex_guard_acquirer<T: NetObject + 'static, S: Subscribable>(
         let (value, _bg_alerter) = &mut **owned_local_lock.deref_mut();
 
         let packet = conn.recv_serialized().await?;
-        log::trace!(target: "citadel", "{:?}/active-channel || obtained packet {:?}", mutex.node_type(), &packet);
+        log::trace!(target: "citadel", "{:?}/active-channel || obtained packet {:?}", mutex.node_type(), packet);
 
         // the adjacent side will return one of two packets. In the first case, we wait until it drops the adjacent lock, in which case,
         // we get a Released packet. The side that gets this will automatically be allowed to acquire the mutex lock
@@ -465,7 +465,7 @@ async fn yield_lock<S: Subscribable + 'static, T: NetObject>(
 
     loop {
         let next_packet = channel.recv_serialized().await?;
-        log::trace!(target: "citadel", "[YIELD LOCK] {:?} received packet: {:?}", channel.node_type(), &next_packet);
+        log::trace!(target: "citadel", "[YIELD LOCK] {:?} received packet: {:?}", channel.node_type(), next_packet);
         match next_packet {
             UpdatePacket::Released(new_value, _) => {
                 lock.deref_mut().0 = bincode::deserialize(&new_value)?;
@@ -615,7 +615,7 @@ mod tests {
             for idx in 1..count {
                 log::trace!(target: "citadel", "Server obtaining lock {idx}");
                 let mut lock = mutex.lock().await.unwrap();
-                log::trace!(target: "citadel", "****Server obtained lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Server obtained lock {} w/val {:?}", idx, *lock);
                 assert_eq!(idx + init_value, *lock);
 
                 *lock += 1;

--- a/netbeam/src/sync/primitives/net_rwlock.rs
+++ b/netbeam/src/sync/primitives/net_rwlock.rs
@@ -375,7 +375,7 @@ async fn net_rwlock_guard_drop_code<T: NetObject, S: Subscribable + 'static>(
 
     loop {
         let packet = conn.recv_serialized::<UpdatePacket>().await?;
-        log::trace!(target: "citadel", "[NetRwLock] [Drop Code] RECV {:?} on {:?}", &packet, conn.node_type());
+        log::trace!(target: "citadel", "[NetRwLock] [Drop Code] RECV {:?} on {:?}", packet, conn.node_type());
 
         match packet {
             UpdatePacket::ReleasedWrite(_new_value) => {
@@ -565,7 +565,7 @@ async fn yield_lock<S: Subscribable + 'static, T: NetObject>(
 
     loop {
         let next_packet = channel.recv_serialized().await?;
-        log::trace!(target: "citadel", "Yield::RECV | {:?} received {:?}", channel.node_type(), &next_packet);
+        log::trace!(target: "citadel", "Yield::RECV | {:?} received {:?}", channel.node_type(), next_packet);
         match next_packet {
             UpdatePacket::ReleasedWrite(new_value) => match &mut lock {
                 LocalLockHolder::Write(val, _) => {
@@ -722,7 +722,7 @@ where
 
     loop {
         let packet = conn.recv_serialized().await?;
-        log::trace!(target: "citadel", "{:?}/active-channel || obtained packet {:?}", rwlock.channel.node_type(), &packet);
+        log::trace!(target: "citadel", "{:?}/active-channel || obtained packet {:?}", rwlock.channel.node_type(), packet);
 
         // the adjacent side will return one of two packets. In the first case, we wait until it drops the adjacent lock, in which case,
         // we get a Released packet. The side that gets this will automatically be allowed to acquire the mutex lock
@@ -914,7 +914,7 @@ mod tests {
             for idx in 1..COUNT {
                 log::trace!(target: "citadel", "Server obtaining lock {idx}");
                 let mut lock = rwlock.write().await.unwrap();
-                log::trace!(target: "citadel", "****Server obtained lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Server obtained lock {} w/val {:?}", idx, *lock);
                 assert_eq!(idx + init_value, *lock);
 
                 *lock += 1;
@@ -984,7 +984,7 @@ mod tests {
             for idx in 0..COUNT {
                 log::trace!(target: "citadel", "Server obtaining lock {idx}");
                 let lock = rwlock.read().await.unwrap();
-                log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, *lock);
                 reads.push(lock);
             }
 
@@ -1009,7 +1009,7 @@ mod tests {
             for idx in 0..COUNT {
                 log::trace!(target: "citadel", "Client obtaining lock {idx}");
                 let lock = rwlock.read().await.unwrap();
-                log::trace!(target: "citadel", "****Client obtained read lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Client obtained read lock {} w/val {:?}", idx, *lock);
                 reads.push(lock);
             }
 
@@ -1045,7 +1045,7 @@ mod tests {
                 log::trace!(target: "citadel", "Server obtaining lock {idx}");
                 let lock = rwlock.read().await.unwrap();
                 citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, *lock);
                 reads.push(lock);
             }
 
@@ -1061,7 +1061,7 @@ mod tests {
                 log::trace!(target: "citadel", "Client obtaining lock {idx}");
                 let lock = rwlock.read().await.unwrap();
                 citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                log::trace!(target: "citadel", "****Client obtained read lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Client obtained read lock {} w/val {:?}", idx, *lock);
                 reads.push(lock);
             }
 
@@ -1103,7 +1103,7 @@ mod tests {
                 log::trace!(target: "citadel", "Server obtaining lock {idx}");
                 let lock = rwlock.read().await.unwrap();
                 citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, *lock);
                 reads.push(lock);
             }
 
@@ -1126,7 +1126,7 @@ mod tests {
                 log::trace!(target: "citadel", "Client obtaining lock {idx}");
                 let lock = rwlock.read().await.unwrap();
                 citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                log::trace!(target: "citadel", "****Client obtained read lock {} w/val {:?}", idx, &*lock);
+                log::trace!(target: "citadel", "****Client obtained read lock {} w/val {:?}", idx, *lock);
                 reads.push(lock);
             }
 
@@ -1176,13 +1176,13 @@ mod tests {
                 if do_read {
                     let lock = rwlock.read().await.unwrap();
                     //citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                    log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, &*lock);
+                    log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, *lock);
                     do_read = false;
                     assert_eq!(server_ref.load(Ordering::Relaxed), *lock);
                 } else {
                     let mut lock = rwlock.write().await.unwrap();
                     //citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                    log::trace!(target: "citadel", "****Server obtained write lock {} w/val {:?}", idx, &*lock);
+                    log::trace!(target: "citadel", "****Server obtained write lock {} w/val {:?}", idx, *lock);
                     do_read = true;
                     *lock = idx;
                     server_ref.store(*lock, Ordering::Relaxed);
@@ -1205,13 +1205,13 @@ mod tests {
                 if do_read {
                     let lock = rwlock.read().await.unwrap();
                     //citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                    log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, &*lock);
+                    log::trace!(target: "citadel", "****Server obtained read lock {} w/val {:?}", idx, *lock);
                     do_read = false;
                     assert_eq!(client_ref.load(Ordering::Relaxed), *lock);
                 } else {
                     let mut lock = rwlock.write().await.unwrap();
                     //citadel_io::time::sleep(std::time::Duration::from_millis(1)).await;
-                    log::trace!(target: "citadel", "****Server obtained write lock {} w/val {:?}", idx, &*lock);
+                    log::trace!(target: "citadel", "****Server obtained write lock {} w/val {:?}", idx, *lock);
                     do_read = true;
                     *lock = idx;
                     client_ref.store(*lock, Ordering::Relaxed);


### PR DESCRIPTION
## Summary

Generalizes netbeam's 2-node `NetMutex`/`NetRwLock` to **n ≥ 2 members with fault tolerance**: new `netbeam::sync::group` module providing `NetGroupMutex<T>` and `NetGroupRwLock<T>`. Purely additive — the existing 2-node primitives and their `citadel_wire` consumers are untouched.

**Algorithm**: each lock is a single CASPaxos-replicated `LockRecord`; every operation (acquire/claim/renew/release/steal/evict/dequeue/downgrade) is a pure CAS function linearized by Prepare/Accept rounds against a **majority** of the configured members. No leader, no election — safety is quorum intersection, so mutual exclusion of grant epochs holds under `f < n/2` crashes and arbitrary partitions; liveness requires a connected majority. Design informed by recent literature (EPaxos\* [arXiv 2511.02743], LeaseGuard [arXiv 2512.15659], Bodega [arXiv 2509.07158], token-DME survey [arXiv 2502.04708], Kleppmann's fencing argument, etcd Jepsen 3.4.3).

Key properties:
- **Leases on local monotonic clocks only** — never a cross-node clock comparison. Crashed holders are stolen after a frozen `(fence, lease_seq)` snapshot stays unchanged for `lease_duration + steal_grace` on the observer's own clock; a steal never grants — the successor runs its own claim round (structurally eliminates stale-grant races).
- **Monotonic fencing tokens** on every grant (`guard.fence()`), plus `guard.invalidated().await` and a `recovered()` poison signal telling the next writer that a predecessor crashed mid-critical-section.
- **Value replicated inside the record** — a release and its value publication commit in one atomic CAS, so a crashed writer's uncommitted mutations are invisible by construction.
- **Write-preferring FIFO** (tokio/etcd rule): readers batch between writers, writers cannot starve; atomic `downgrade()`, no upgrade (deadlocks by design).
- **Serializable network state**: `SnapshotAcceptorStore` round-trips a member's voter state through bytes — a fully-restarted group (or any majority) resumes from the last committed value, and a lone returning member can `peek_value()` its last known state offline.

## Usage

```rust
use netbeam::sync::group::*;
use std::{collections::HashMap, sync::Arc, time::Duration};

// Each member wires a full mesh: one ReliableOrderedStreamToTarget per peer
// (any framed transport works — TCP/TLS/QUIC via the usual netbeam adapters).
let peers: HashMap<MemberId, Arc<dyn ReliableOrderedStreamToTarget>> = wire_mesh().await?;
let transport = GroupTransport::new(MemberId(1), peers);

// All timing knobs are explicit (safety/liveness tradeoffs — no hidden defaults).
let cfg = GroupLockConfig::new(
    vec![MemberId(1), MemberId(2), MemberId(3)], // static membership, n >= 2
    MemberId(1),                                 // local id
    MemberId(1),                                 // initial-value owner
    Duration::from_secs(3),                      // lease_duration
    Duration::from_millis(750),                  // renew_interval (< lease/2)
    Duration::from_secs(1),                      // steal_grace
    Duration::from_secs(30),                     // acquire_timeout
    Duration::from_secs(2),                      // round_timeout
    Duration::from_millis(50),                   // cas_backoff_base
    Duration::from_millis(500),                  // waiter_poll_interval
)?;

// Byte-serializable voter state: export on shutdown, restore on restart.
let store = Arc::new(SnapshotAcceptorStore::new());

// Every member calls create(); exactly the owner passes Some(initial).
let counter = NetGroupMutex::<u64>::create(
    transport.clone(), LockId::from_name("shared-counter"), cfg.clone(), store.clone(),
    Some(0), // owner supplies the initial value; other members pass None
).await?;

// Mutex: exclusive access across all n members, value handed off atomically.
let mut guard = counter.lock().await?;
*guard += 1;                       // replicated to a majority on release
let fence = guard.fence();         // fencing token for external systems
if let Some(crash) = guard.recovered() {
    // previous writer died mid-critical-section; its uncommitted work was discarded
    log::warn!("recovered lock from crashed member {:?}", crash.member);
}
guard.release().await?;            // or just drop(guard) — best-effort release

// RwLock: readers batch concurrently group-wide, writers are prioritized.
let doc = NetGroupRwLock::<String>::create(
    transport, LockId::from_name("shared-doc"), cfg, store.clone(), Some(String::new()),
).await?;
let r = doc.read().await?;         // concurrent with other members' readers
drop(r);
let mut w = doc.write().await?;    // exclusive; queued readers wait behind us
w.push_str("hello");
let r = w.downgrade().await?;      // atomic write->read; readers may now join

// Survive a full-group shutdown: persist, then restore next session.
let bytes = store.to_bytes()?;                        // -> your storage (disk, RE-VFS, ...)
let restored = SnapshotAcceptorStore::from_bytes(&bytes)?;
let (version, last) = peek_value::<String>(&restored, LockId::from_name("shared-doc"))?
    .expect("last known value, readable offline before any quorum re-forms");
```

## Fault tolerance (all exercised by tests)

| Failure | Behavior |
|---|---|
| Holder crashes mid-CS | Stolen after the lease window; next writer gets `recovered()`; uncommitted mutations invisible |
| Waiter crashes in queue | Evicted by whoever it blocks; FIFO never wedges |
| Partition (minority holder) | Holder self-invalidates locally; majority side steals and proceeds; healed stale release is fenced (`Stolen`) |
| f = ⌈n/2⌉−1 voters down | Fully live |
| No majority | Acquires fail fast (`QuorumUnavailable`/`Timeout`) — never silent success |
| Full-group restart | Any majority restored from `SnapshotAcceptorStore` bytes recovers the last committed value exactly |

## Testing

- **Pure table tests** over every `apply()` precondition (idempotency under ambiguous round replay included).
- **Seeded deterministic simulator**: 200 seeds × 300 steps (plus an `#[ignore]`d 6M-step stress mode, ~7 s), 6 safety invariants asserted after every committed round — no violations.
- **8 directed adversarial tests**: stale-ballot overwrites, dueling proposers across intersecting quorums, forged accepts, stale steal snapshots, stolen-writer fencing, write-preference bypass, re-init, voter amnesia vs persisted state.
- **Async integration + fault injection** on an in-memory n-member mesh (n = 3, 5) with severable links.
- A 3-dimension adversarial review pass confirmed 14 findings pre-merge (idempotency/withdrawal after ambiguous rounds, resource lifecycle, overflow hardening) — all fixed with regression tests.
- `netbeam`: 81 passed / 0 failed; both workspace clippy gates (`-D warnings`) clean; wasm32 gate (`citadel_sdk`) passes; existing 2-node tests untouched and green.

## Known v1 caveats (documented in module docs)

- Crash-stop voter model by default: a voter that restarts with the ephemeral store must not rejoin; supply a durable (write-before-reply) `AcceptorStateStore` for strict crash-recovery. `SnapshotAcceptorStore` covers graceful-shutdown/full-restart recovery.
- Static membership (dynamic join/drop = CASPaxos reconfiguration, designed and queued as v2).
- Full record travels in consensus messages (right shape for small groups/values, netbeam's use case).
- `n = 2` degenerates to majority-of-2: correct but no fault tolerance (by arithmetic).
