### PR TITLE
fix(bench): repair validate_message_packet, which panics on anti-replay

### DIFF
--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -504,10 +504,11 @@ Payload-budget facts discovered while benching (drove the 1150→1000 B default)
   `SendDatagramError::TooLarge` propagates out of the pump): a 1150 B send wedged the receiver
   forever when P2P selected QUIC, and worked when it selected the raw hole-punched socket. P0-i
   (non-fatal per-packet TooLarge + `max_payload_len()`) fixes exactly this.
-- Pre-existing bug (not fixed here): `crypto_hot_path`'s `validate_message_packet` group panics with
-  "Anti-replay-attack: invalid" on any run reaching a 2nd iteration — the receiver's anti-replay
-  container rejects re-validating the same packet. `udp_media_vs_srtp` protects a fresh packet per
-  iteration (untimed setup) instead.
+- Fixed in #274 (was a pre-existing bug): `crypto_hot_path`'s `validate_message_packet` group
+  panicked with "Anti-replay-attack: invalid" on any run reaching a 2nd iteration — the receiver's
+  anti-replay container rejects re-validating the same packet. It now protects a fresh packet per
+  iteration inside an untimed `iter_batched` setup closure, matching the approach
+  `udp_media_vs_srtp` already used.
 
 Artifacts: `bench/udp_media_results.json` (unpaced master baseline). After P0/P1 land, re-run both
 benches and append the AFTER table here (same commands, same machine).

--- a/citadel_crypt/benches/crypto_hot_path.rs
+++ b/citadel_crypt/benches/crypto_hot_path.rs
@@ -69,14 +69,18 @@ fn bench_validate(c: &mut Criterion) {
     group.throughput(Throughput::Bytes(MSG_LEN as u64));
     for (name, enc) in ALGOS {
         let (alice, bob) = make_ratchets(*enc, sec);
-        let mut protected = plaintext_packet();
-        alice
-            .protect_message_packet(Some(sec), HEADER_LEN, &mut protected)
-            .unwrap();
         group.bench_function(*name, |b| {
             b.iter_batched(
                 || {
-                    let mut p = protected.clone();
+                    // Protect a FRESH packet per iteration. The anti-replay
+                    // container rejects a repeated PID, so a single
+                    // pre-protected packet can only be validated once; reusing
+                    // it panics on the second iteration. `iter_batched` does not
+                    // time the setup closure, so this still isolates validate.
+                    let mut p = plaintext_packet();
+                    alice
+                        .protect_message_packet(Some(sec), HEADER_LEN, &mut p)
+                        .unwrap();
                     let header = p.split_to(HEADER_LEN);
                     (header, p)
                 },


### PR DESCRIPTION
## The bug

`bench_validate` in `citadel_crypt/benches/crypto_hot_path.rs` protects a single
packet **outside** the measurement loop, then validates that same packet on
every iteration:

```rust
let mut protected = plaintext_packet();
alice.protect_message_packet(Some(sec), HEADER_LEN, &mut protected).unwrap();
group.bench_function(*name, |b| {
    b.iter_batched(
        || {
            let mut p = protected.clone();   // same PID every iteration
            ...
```

The anti-replay container does exactly what it should: the first iteration
consumes the PID, and every one after it returns
`Anti-replay-attack: invalid`, so the `.unwrap()` panics during warm-up.

```
thread 'main' panicked at citadel_crypt/benches/crypto_hot_path.rs:113:26:
called `Result::unwrap()` on an `Err` value: NetworkError { code: Encrypt (10),
message: "Encryption error: Anti-replay-attack: invalid" }
```

Deterministic and host-independent. Warm-up alone runs more than one iteration,
so this bench has never completed on any machine, which matches
`bench/RESULTS.md` carrying no `validate_message_packet` figures anywhere. The
receive half of the per-message crypto hot path has never been measured.

## The fix

Move the protect into the `iter_batched` setup closure. Criterion excludes
setup from the timed region, so the measurement still isolates
`validate_message_packet`, but each iteration now gets a freshly protected
packet with a unique PID. Ordering is preserved, since `iter_batched` builds
the batch and then runs the routine over it in order.

Nine lines added, five removed.

## First numbers

GB10 (20-core ARM: 10x Cortex-X925 + 10x Cortex-A725), criterion, 100 samples,
256-byte message, `SecurityLevel::Standard`, ARMv8 hardware AES enabled.
Protect figures from the same box included for reference.

| algorithm | validate | protect |
|---|---|---|
| aes_gcm_256 | 1.5164 us | 1.7162 us |
| chacha20_poly1305 | 1.9680 us | 2.1940 us |
| ascon80pq | 1.9273 us | 2.2526 us |

Validate runs 12% to 14% faster than protect across all three. That tracks: the
send path derives a nonce with a `blake3::keyed_hash`, where the receive path
reads the nonce off the packet.

## Verify

```
cargo bench -p citadel_crypt --bench crypto_hot_path -- validate
```

Three rows, no panic.
