### PR TITLE
fix: advertise a routable internal candidate, not the wildcard bind address

### DIFF
--- a/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
+++ b/citadel_wire/src/udp_traversal/udp_hole_puncher.rs
@@ -191,10 +191,16 @@ async fn driver_inner(
     let local_initial_socket = get_optimal_bind_socket(local_nat_type, peer_nat_type)?;
     let internal_bind_addr_optimal = local_initial_socket.local_addr()?;
     let mut sockets = vec![local_initial_socket];
-    let mut internal_addresses = vec![internal_bind_addr_optimal];
+    let mut internal_addresses = vec![routable_candidate(
+        internal_bind_addr_optimal,
+        local_nat_type,
+    )];
     if internal_bind_addr_optimal.is_ipv6() {
         let additional_socket = crate::socket_helpers::get_udp_socket("0.0.0.0:0")?;
-        internal_addresses.push(additional_socket.local_addr()?);
+        internal_addresses.push(routable_candidate(
+            additional_socket.local_addr()?,
+            local_nat_type,
+        ));
         sockets.push(additional_socket);
     }
 
@@ -295,6 +301,37 @@ async fn probe_reflexive_addrs(
 /// Suppose A binds to ipv6 addr, and B binds to ipv4 addr, then B cannot send packets to
 /// A. Only A can send to B via ipv4-mapped-v6 addrs. In order for B to send packets back to A,
 /// B will need the ipv4 address of A.
+/// Replaces a wildcard bind address with one a peer can actually reach.
+///
+/// `get_optimal_bind_socket` binds `[::]:0` or `0.0.0.0:0`, so `local_addr()`
+/// returns that wildcard with a real ephemeral port. Those values are advertised
+/// as `internal_bind_addrs` — candidates the peer is asked to punch to — and a
+/// peer cannot connect to `0.0.0.0` or `[::]`. Observed in CI as
+/// `[Hole-punch/Err] invalid remote address: 0.0.0.0:54960` and the `[::]`
+/// equivalent, in whichever family the branch above chose.
+///
+/// Substitution rather than removal, and the position is kept: `HolePunchConfig`
+/// asserts `peer_internal_addrs.len() == local_sockets.len()`, so dropping an
+/// entry desynchronises the peer into an assertion failure — and each internal
+/// address also carries the reflexive candidates in its band-set, so a dropped
+/// entry would take good STUN-derived addresses with it.
+///
+/// Falls back to the wildcard unchanged when no internal IP is known, which is
+/// the previous behaviour.
+fn routable_candidate(addr: SocketAddr, local_nat_type: &NatType) -> SocketAddr {
+    if !addr.ip().is_unspecified() {
+        return addr;
+    }
+    match local_nat_type.ip_info.as_ref().map(|info| info.internal_ip) {
+        // Only substitute within the same address family; the socket is bound to
+        // that family's wildcard and the peer pairs candidates positionally.
+        Some(internal_ip) if internal_ip.is_ipv4() == addr.is_ipv4() => {
+            SocketAddr::new(internal_ip, addr.port())
+        }
+        _ => addr,
+    }
+}
+
 pub fn get_optimal_bind_socket(
     local_nat_info: &NatType,
     peer_nat_info: &NatType,
@@ -495,5 +532,77 @@ mod tests {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod routable_candidate_tests {
+    use super::routable_candidate;
+    use crate::standard::nat_identification::NatType;
+    use async_ip::IpAddressInfo;
+    use std::net::{IpAddr, SocketAddr};
+    use std::str::FromStr;
+
+    fn nat_with(internal_ip: Option<&str>) -> NatType {
+        NatType {
+            ip_info: internal_ip.map(|ip| IpAddressInfo {
+                internal_ip: IpAddr::from_str(ip).unwrap(),
+                external_ipv6: None,
+            }),
+            ..Default::default()
+        }
+    }
+
+    /// The defect: a socket bound to a wildcard advertises that wildcard, and a
+    /// peer cannot punch to `0.0.0.0`.
+    #[test]
+    fn a_wildcard_is_replaced_by_the_internal_ip_keeping_the_port() {
+        let advertised = routable_candidate(
+            SocketAddr::from_str("0.0.0.0:54960").unwrap(),
+            &nat_with(Some("10.1.0.156")),
+        );
+        assert_eq!(
+            advertised,
+            SocketAddr::from_str("10.1.0.156:54960").unwrap(),
+            "the peer was handed an address it cannot connect to"
+        );
+    }
+
+    #[test]
+    fn an_ipv6_wildcard_is_replaced_by_an_ipv6_internal_ip() {
+        let advertised = routable_candidate(
+            SocketAddr::from_str("[::]:34464").unwrap(),
+            &nat_with(Some("fd00::1")),
+        );
+        assert_eq!(advertised, SocketAddr::from_str("[fd00::1]:34464").unwrap());
+    }
+
+    /// Candidates are paired positionally with sockets bound to a specific
+    /// family, so substituting across families would advertise an address the
+    /// local socket cannot even send from.
+    #[test]
+    fn a_family_mismatch_is_left_alone() {
+        let wildcard = SocketAddr::from_str("[::]:34464").unwrap();
+        assert_eq!(
+            routable_candidate(wildcard, &nat_with(Some("10.1.0.156"))),
+            wildcard,
+            "an IPv4 internal address was substituted into an IPv6 candidate"
+        );
+    }
+
+    /// Previous behaviour when nothing better is known.
+    #[test]
+    fn without_ip_info_the_address_is_unchanged() {
+        let wildcard = SocketAddr::from_str("0.0.0.0:54960").unwrap();
+        assert_eq!(routable_candidate(wildcard, &nat_with(None)), wildcard);
+    }
+
+    #[test]
+    fn a_routable_address_is_never_touched() {
+        let real = SocketAddr::from_str("192.168.1.7:9000").unwrap();
+        assert_eq!(
+            routable_candidate(real, &nat_with(Some("10.1.0.156"))),
+            real
+        );
     }
 }


### PR DESCRIPTION
Fixes the defect described in #279.

## The defect

`get_optimal_bind_socket` binds `[::]:0` or `0.0.0.0:0`, so `local_addr()` returns **that wildcard** with a real ephemeral port — and that value is advertised as an `internal_bind_addr`, i.e. a candidate the peer is asked to punch to. A peer cannot connect to `0.0.0.0` or `[::]`.

Observed in CI as `[Hole-punch/Err] invalid remote address: 0.0.0.0:54960` and the `[::]` form, each in whichever family the branch above chose — one occurrence per failing run, across two independent shards.

## Why substitution, and why the position is preserved

Both constraints come from `hole_punch_config.rs` and neither is visible from the failure logs:

```rust
// line 150 — candidates are POSITIONALLY paired with the local sockets
assert_eq!(peer_internal_addrs.len(), local_sockets.len());
```

Dropping an entry desynchronises that count and trips the assertion on the peer.

```rust
for peer_internal_addr in peer_internal_addrs {
    let mut bands = /* predicted from peer_internal_addr */;
    bands.extend(peer_reflexive_addrs.iter().map(...));   // INSIDE the loop
```

Each internal address also carries **every reflexive address** in its band-set, so removing the wildcard entry would discard good STUN-derived candidates along with it.

So the change replaces the IP in place, keeps the port and the position, substitutes only within the same address family, and falls back to the wildcard unchanged when no internal IP is known — the previous behaviour.

## What is and is not claimed

The defect is certain: an address no peer can use is advertised as one they should try. **Whether it fully accounts for the 30s traversal timeouts is not proven** — the reflexive candidates remain valid, so the punch is not left with nothing.

I could not reproduce the failing condition locally: every environment available punches over loopback in microseconds. What I could measure is the shape of the failure in CI — negotiation is bimodal, succeeding in 3.5–4.6µs or never arriving within the 5s budget, with nothing in between across 46 samples on two shards.

## Verification

- `citadel_wire` lib suite: 29 passed (24 existing + 5 new)
- The 5 new tests cover substitution, the IPv6 case, the family-mismatch guard, the no-`ip_info` fallback, and that a routable address is never touched
- Control: making `routable_candidate` return its input unchanged reddens exactly the two substitution tests

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7