### PR TITLE
fix: external_ipv6 must actually be an IPv6 address

### DIFF
--- a/async_ip/src/lib.rs
+++ b/async_ip/src/lib.rs
@@ -126,7 +126,7 @@ pub async fn get_all_multi_concurrent_from(
     let (res0, res2) = citadel_io::tokio::join!(internal_ip_future, external_ipv6_future);
     let internal_ip =
         res0.ok_or_else(|| citadel_io::error!(citadel_io::ErrorCode::IpInternalUnobtainable))?;
-    let external_ipv6 = res2.ok().map(|r| r.0);
+    let external_ipv6 = res2.ok().map(|r| r.0).and_then(only_ipv6);
 
     Ok(IpAddressInfo {
         internal_ip,
@@ -137,6 +137,17 @@ pub async fn get_all_multi_concurrent_from(
 /// Returns all possible IPs for this node
 pub async fn get_all(client: Option<reqwest::Client>) -> Result<IpAddressInfo, IpRetrieveError> {
     get_all_from(client, URL_V6).await
+}
+
+/// The "v6" endpoints answer over whatever transport reaches them, so on a host
+/// with no IPv6 they reply over IPv4 with an IPv4 address. Storing that as
+/// `external_ipv6` is not merely untidy: `citadel_wire`'s
+/// `get_optimal_bind_socket` treats `external_ipv6.is_some()` on both peers as
+/// "both nodes have an external IPv6 address" and binds `[::]:0`. The hole
+/// puncher then advertises an IPv6 candidate on a host that has no IPv6
+/// internal address to offer, and the peer cannot reach it.
+fn only_ipv6(ip: IpAddr) -> Option<IpAddr> {
+    ip.is_ipv6().then_some(ip)
 }
 
 /// Gets IP info concurrently using custom multiple internal sources
@@ -150,7 +161,7 @@ pub async fn get_all_from(
     let (res0, res2) = citadel_io::tokio::join!(internal_ip_future, external_ipv6_future);
     let internal_ip =
         res0.ok_or_else(|| citadel_io::error!(citadel_io::ErrorCode::IpInternalUnobtainable))?;
-    let external_ipv6 = res2.ok();
+    let external_ipv6 = res2.ok().and_then(only_ipv6);
 
     Ok(IpAddressInfo {
         internal_ip,
@@ -298,5 +309,38 @@ mod tests {
         // Trimming must not turn a multi-token body into a valid parse.
         assert!(parse_ip_response("1.2.3.4 5.6.7.8").is_err());
         assert!(parse_ip_response("<html>error</html>").is_err());
+    }
+}
+
+#[cfg(test)]
+mod external_ipv6_family_tests {
+    use super::only_ipv6;
+    use std::net::IpAddr;
+    use std::str::FromStr;
+
+    /// The defect: a "v6" endpoint reached over IPv4 answers with an IPv4
+    /// address, and storing it as `external_ipv6` makes
+    /// `get_optimal_bind_socket` bind `[::]:0` on a host with no IPv6. The hole
+    /// puncher then advertises an IPv6 candidate it has no IPv6 internal
+    /// address to substitute for, and the peer cannot reach it. Observed in CI
+    /// as `invalid remote address: [::]:47790` on a runner whose only internal
+    /// address was `10.1.1.120`.
+    #[test]
+    fn an_ipv4_answer_is_not_an_external_ipv6_address() {
+        assert_eq!(
+            only_ipv6(IpAddr::from_str("172.208.127.86").unwrap()),
+            None,
+            "an IPv4 address was accepted as the external IPv6 address"
+        );
+    }
+
+    #[test]
+    fn a_real_ipv6_answer_is_kept() {
+        let v6 = IpAddr::from_str("2001:db8::1").unwrap();
+        assert_eq!(
+            only_ipv6(v6),
+            Some(v6),
+            "a genuine IPv6 address was discarded"
+        );
     }
 }

--- a/async_ip/src/lib.rs
+++ b/async_ip/src/lib.rs
@@ -147,7 +147,14 @@ pub async fn get_all(client: Option<reqwest::Client>) -> Result<IpAddressInfo, I
 /// puncher then advertises an IPv6 candidate on a host that has no IPv6
 /// internal address to offer, and the peer cannot reach it.
 fn only_ipv6(ip: IpAddr) -> Option<IpAddr> {
-    ip.is_ipv6().then_some(ip)
+    match ip {
+        // An IPv4-mapped address (`::ffff:a.b.c.d`) answers `is_ipv6()` with
+        // true while representing no IPv6 connectivity at all, so a bare
+        // `is_ipv6()` check would let exactly the same failure through in a
+        // different costume.
+        IpAddr::V6(v6) if v6.to_ipv4_mapped().is_none() => Some(ip),
+        _ => None,
+    }
 }
 
 /// Gets IP info concurrently using custom multiple internal sources
@@ -341,6 +348,17 @@ mod external_ipv6_family_tests {
             only_ipv6(v6),
             Some(v6),
             "a genuine IPv6 address was discarded"
+        );
+    }
+
+    /// `is_ipv6()` is true for `::ffff:a.b.c.d`, which represents no IPv6
+    /// connectivity — the same defect wearing a different costume.
+    #[test]
+    fn an_ipv4_mapped_address_is_not_an_external_ipv6_address() {
+        assert_eq!(
+            only_ipv6(IpAddr::from_str("::ffff:172.208.127.86").unwrap()),
+            None,
+            "an IPv4-mapped address was accepted as the external IPv6 address"
         );
     }
 }


### PR DESCRIPTION
Completes the other half of #279. #280 fixed the IPv4 case; this fixes the IPv6 one, at its source.

## The defect

`async_ip` sets `IpAddressInfo.external_ipv6` to whatever the "v6" endpoint returns, with **no check that the answer is IPv6**. Those endpoints answer over whatever transport reaches them, so on a host with no IPv6 they reply over IPv4 — with an IPv4 address.

## Why it matters beyond tidiness

`citadel_wire::get_optimal_bind_socket` reads `external_ipv6.is_some()` on both peers as "both nodes have an external IPv6 address" and binds `[::]:0`. The hole puncher then advertises an IPv6 candidate on a host that has **no IPv6 internal address to substitute for it**, so #280's `routable_candidate` correctly declines (substituting across families would advertise an address the local socket cannot send from) and the wildcard goes out anyway.

## Evidence

After #280 merged, CI still shows one occurrence per failing shard:

```
[Hole-punch/Err] ... invalid remote address: [::]:47790
```

on a runner whose NAT report reads:

```
external_ipv6: Some(172.208.127.86)   <-- an IPv4 address
internal_ip:   10.1.1.120
```

The IPv4 half is gone — `0.0.0.0` no longer appears anywhere, and two jobs that previously failed on it (`test:hard-disconnect`, a pure messaging test, and `test:reconnect-p2p-only`) now pass with zero `invalid remote address` and zero `[Hole-punch/Timeout]` lines. So #280 works; this is the remaining path.

With this change, an IPv4-only host reports `external_ipv6: None`, `get_optimal_bind_socket` takes the IPv4 branch, and #280 substitutes the real internal address. The two fixes compose.

## Verification

- `async_ip` lib suite: 6 passed, including 2 new
- Control: making `only_ipv6` accept anything reddens the IPv4 assertion specifically

## Scope note

This changes what `external_ipv6` reports on IPv4-only hosts, from a wrong IPv4 address to `None`. Any consumer treating it as "we have some external address" would see a behaviour change — I found no such consumer, but you know the tree better than I do.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7