### PR TITLE
fix: a timed-out hole-punch attempt no longer leaks its tasks and sockets

### DIFF
--- a/citadel_wire/src/udp_traversal/abort_on_drop.rs
+++ b/citadel_wire/src/udp_traversal/abort_on_drop.rs
@@ -1,0 +1,151 @@
+//! A spawned task that stops when you stop waiting for it.
+//!
+//! Dropping a tokio `JoinHandle` **detaches** the task; it does not abort it.
+//! That is the right default for fire-and-forget work and the wrong one for
+//! everything in the hole-punch driver, which is wrapped in a timeout and
+//! retried:
+//!
+//! ```text
+//! driver()                       // up to MAX_RETRIES attempts
+//!   timeout(driver_inner(..))    // on timeout the inner future is DROPPED
+//!     DualStackUdpHolePuncher    // dropped
+//!       JoinHandle<drive(..)>    // dropped -> DETACHED, still running
+//!         N x JoinHandle<..>     // also dropped, also still running
+//! ```
+//!
+//! `drive` has no exit path on failure — it ends by waiting on a `done` signal
+//! or a rebuilder, neither of which arrives once nobody is listening — so each
+//! timed-out attempt left a task looping forever, holding its bound UDP sockets
+//! and a 100ms retransmit timer. The retry loop then bound a fresh set and did
+//! it again. Nothing errored, and the sockets were never released for the
+//! lifetime of the process.
+//!
+//! Wrapping the handle makes the intent explicit and non-optional: as long as
+//! somebody awaits the task it runs; the moment the awaiting future is dropped,
+//! so is the task.
+
+use futures::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// A `JoinHandle` that aborts its task on drop, and forwards `poll` otherwise.
+///
+/// `T` is the task's output. Polling yields `Err` if the task panicked or was
+/// aborted, exactly as awaiting a `JoinHandle` does.
+pub struct AbortOnDrop<T> {
+    handle: citadel_io::tokio::task::JoinHandle<T>,
+}
+
+impl<T> AbortOnDrop<T> {
+    /// Spawn `future` such that dropping the returned handle aborts it.
+    pub fn spawn<F>(future: F) -> Self
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        Self {
+            handle: citadel_io::tokio::task::spawn(future),
+        }
+    }
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        // Idempotent, and a no-op once the task has finished.
+        self.handle.abort();
+    }
+}
+
+impl<T> Future for AbortOnDrop<T> {
+    type Output = Result<T, citadel_io::tokio::task::JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.handle).poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use citadel_io::tokio;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// A task that never returns, so only cancellation can stop it — the shape
+    /// of `drive` once its peer has stopped listening.
+    async fn forever(ticks: Arc<AtomicUsize>) {
+        loop {
+            ticks.fetch_add(1, Ordering::SeqCst);
+            citadel_io::tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    async fn settle() {
+        citadel_io::tokio::time::sleep(Duration::from_millis(60)).await;
+    }
+
+    #[tokio::test]
+    async fn dropping_the_handle_stops_the_task() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let handle = AbortOnDrop::spawn(forever(ticks.clone()));
+
+        settle().await;
+        let while_held = ticks.load(Ordering::SeqCst);
+        assert!(while_held > 0, "the task never ran at all");
+
+        drop(handle);
+        settle().await;
+        let after_drop = ticks.load(Ordering::SeqCst);
+
+        settle().await;
+        assert_eq!(
+            ticks.load(Ordering::SeqCst),
+            after_drop,
+            "the task kept running after its handle was dropped"
+        );
+    }
+
+    /// The control for the test above, kept as a test rather than run once by
+    /// hand: it pins that a bare `spawn` really does detach, so
+    /// `dropping_the_handle_stops_the_task` is measuring the wrapper and not
+    /// something the runtime would have done anyway.
+    #[tokio::test]
+    async fn a_bare_join_handle_detaches_instead() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let handle = citadel_io::tokio::task::spawn(forever(ticks.clone()));
+
+        settle().await;
+        drop(handle);
+        settle().await;
+        let after_drop = ticks.load(Ordering::SeqCst);
+
+        settle().await;
+        assert!(
+            ticks.load(Ordering::SeqCst) > after_drop,
+            "a bare JoinHandle stopped its task on drop; the wrapper under test \
+             would then be measuring nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_completed_task_still_yields_its_value() {
+        let handle = AbortOnDrop::spawn(async { 7u8 });
+        assert_eq!(handle.await.unwrap(), 7);
+    }
+
+    /// Aborting an already-finished task must not turn its success into an
+    /// error, or every successful traversal would report a JoinError on the way
+    /// out.
+    #[tokio::test]
+    async fn finishing_before_the_drop_is_not_an_abort() {
+        let ticks = Arc::new(AtomicUsize::new(0));
+        let counter = ticks.clone();
+        let handle = AbortOnDrop::spawn(async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+        settle().await;
+        assert!(handle.await.is_ok(), "a finished task reported an error");
+        assert_eq!(ticks.load(Ordering::SeqCst), 1);
+    }
+}

--- a/citadel_wire/src/udp_traversal/mod.rs
+++ b/citadel_wire/src/udp_traversal/mod.rs
@@ -57,6 +57,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use uuid::Uuid;
 
+pub mod abort_on_drop;
 pub mod hole_punch_config;
 pub mod hole_punched_socket;
 

--- a/citadel_wire/src/udp_traversal/multi/mod.rs
+++ b/citadel_wire/src/udp_traversal/multi/mod.rs
@@ -57,11 +57,15 @@
 //! - [`netbeam::multiplex`] - Connection multiplexing
 //!
 
+use crate::udp_traversal::abort_on_drop::AbortOnDrop;
 use crate::udp_traversal::hole_punch_config::HolePunchConfig;
 use crate::udp_traversal::hole_punched_socket::HolePunchedUdpSocket;
 use crate::udp_traversal::linear::encrypted_config_container::HolePunchConfigContainer;
 use crate::udp_traversal::linear::SingleUDPHolePuncher;
 use crate::udp_traversal::{HolePunchID, NatTraversalMethod};
+// Still used by the loser-rebuild race below, where "first socket wins and the
+// other attempt is abandoned" IS the intended meaning. It is NOT the intended
+// meaning for the sender/reader pair -- see the comment there.
 use citadel_io::tokio::sync::mpsc::UnboundedReceiver;
 use futures::future::select_ok;
 use futures::stream::FuturesUnordered;
@@ -140,8 +144,14 @@ impl DualStackUdpHolePuncher {
         }
 
         // TODO: Setup concurrent UPnP AND NAT-PMP async https://docs.rs/natpmp/latest/natpmp/struct.NatpmpAsync.html
+        // AbortOnDrop, not `spawn`. `driver` in udp_hole_puncher.rs wraps this
+        // whole future in a timeout and retries; on timeout the future is
+        // dropped, and a dropped JoinHandle DETACHES rather than aborts. `drive`
+        // has no exit path once nobody is listening, so every timed-out attempt
+        // used to leave a task looping forever on its bound UDP sockets, and
+        // the next attempt bound a fresh set. See udp_traversal/abort_on_drop.rs.
         let task = async move {
-            citadel_io::tokio::task::spawn(drive(hole_punchers, relative_node_type, napp))
+            AbortOnDrop::spawn(drive(hole_punchers, relative_node_type, napp))
                 .await
                 .map_err(|err| anyhow::Error::msg(format!("panic in hole puncher: {err:?}")))?
         };
@@ -232,9 +242,10 @@ async fn drive(
             (res, hole_puncher)
         };
 
-        let task = citadel_io::tokio::task::spawn(task);
-
-        futures.push(task);
+        // Also abort-on-drop: these hold the individual sockets, and
+        // `FuturesUnordered` drops whatever it still holds when `drive` itself
+        // is cancelled.
+        futures.push(AbortOnDrop::spawn(task));
     }
 
     let current_enqueued_set: &citadel_io::tokio::sync::Mutex<Vec<HolePunchedUdpSocket>> =
@@ -512,14 +523,24 @@ async fn drive(
 
     log::trace!(target: "citadel", "[DualStack] Executing hole-puncher ....");
     let sender_reader_combo = async move {
-        let res = futures::future::select_ok([
-            Box::pin(futures_resolver)
-                as Pin<Box<dyn Future<Output = Result<(), anyhow::Error>> + Send>>,
-            Box::pin(reader),
-        ])
-        .await;
-        if let Some(err) = res.as_ref().err() {
-            log::warn!(target: "citadel", "Both reader/resolver futures failed: {err:?}")
+        // `join`, not `select_ok`. `select_ok` returns on the FIRST Ok and drops
+        // the other future -- and the resolver finishing first is the ordinary
+        // case, not an edge one: it completes as soon as every local puncher has
+        // resolved, including when they all failed. Dropping the reader there
+        // means a `Winner` the remote sends afterwards is never consumed,
+        // `commanded_winner` is never set, and both sides sit until the whole
+        // attempt times out. That is precisely the asymmetric-NAT recovery this
+        // protocol exists for.
+        //
+        // This arm intentionally never completes (it ends in `pending`); its job
+        // is to keep BOTH futures polled. Termination belongs to the `select!`
+        // below, via `done_rx` or the rebuilder.
+        let (resolver, reader) = futures::future::join(futures_resolver, reader).await;
+        if let Err(err) = resolver {
+            log::warn!(target: "citadel", "Hole-puncher resolver future failed: {err:?}")
+        }
+        if let Err(err) = reader {
+            log::warn!(target: "citadel", "Hole-puncher reader future failed: {err:?}")
         }
 
         // Just wait for the background process to finish up
@@ -577,4 +598,72 @@ async fn receive(
     conn.recv()
         .await
         .ok_or_else(|| anyhow::Error::msg("recv from bichannel failed: stream ended"))?
+}
+
+#[cfg(test)]
+mod sender_reader_combo_tests {
+    //! The sender/reader pair in `drive` must keep BOTH futures polled.
+    //!
+    //! These pin the SHAPE of that combination, not the whole of `drive` —
+    //! reproducing the real thing needs two live `NetworkEndpoint`s and a NAT.
+    //! What they do establish is the property the bug turned on: the resolver
+    //! completing successfully must not stop the reader from consuming a signal
+    //! that arrives afterwards.
+    use citadel_io::tokio;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// A late signal, of the kind `DualStackCandidateSignal::Winner` is: it
+    /// arrives after local resolution has already finished.
+    async fn late_signal(consumed: Arc<AtomicBool>) -> Result<(), anyhow::Error> {
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        consumed.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// The fix.
+    #[tokio::test]
+    async fn a_reader_still_runs_after_the_resolver_succeeds() {
+        let consumed = Arc::new(AtomicBool::new(false));
+        let resolver = async { Ok::<_, anyhow::Error>(()) };
+
+        let combo = async {
+            let _ = futures::future::join(resolver, late_signal(consumed.clone())).await;
+        };
+        tokio::time::timeout(Duration::from_millis(500), combo)
+            .await
+            .expect("the combination should finish once both halves do");
+
+        assert!(
+            consumed.load(Ordering::SeqCst),
+            "the reader was not polled after the resolver completed"
+        );
+    }
+
+    /// The control, kept as a test: `select_ok` really does drop the loser, so
+    /// the test above is measuring the change and not something both
+    /// combinators would have done.
+    #[tokio::test]
+    async fn select_ok_would_have_dropped_the_reader() {
+        let consumed = Arc::new(AtomicBool::new(false));
+        let resolver = async { Ok::<_, anyhow::Error>(()) };
+        let reader = late_signal(consumed.clone());
+
+        let _ = futures::future::select_ok([
+            Box::pin(resolver)
+                as std::pin::Pin<
+                    Box<dyn futures::Future<Output = Result<(), anyhow::Error>> + Send>,
+                >,
+            Box::pin(reader),
+        ])
+        .await;
+
+        // Give the dropped future every chance to have run anyway.
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert!(
+            !consumed.load(Ordering::SeqCst),
+            "select_ok kept the reader alive, so the join above proves nothing"
+        );
+    }
 }


### PR DESCRIPTION
Two defects in `citadel_wire/src/udp_traversal/multi/mod.rs`, both silent.

### 1. Leaked tasks — a dropped `JoinHandle` **detaches**, it does not abort

```
driver()                       // up to MAX_RETRIES attempts
  timeout(driver_inner(..))    // on timeout the inner future is DROPPED
    DualStackUdpHolePuncher    // dropped
      JoinHandle<drive(..)>    // dropped -> DETACHED, still running
        N x JoinHandle<..>     // also dropped, also still running
```

`drive` has no exit path once nobody is listening — it ends by awaiting a done
signal or the rebuilder, neither of which arrives. So every timed-out attempt
left a task looping forever on its bound UDP sockets and a 100 ms retransmit
timer, and the retry loop then bound a fresh set and did it again. Nothing
errored; nothing was released for the life of the process.

`AbortOnDrop` (new, `udp_traversal/abort_on_drop.rs`) makes the intent explicit
and non-optional, and is applied to both the `drive` spawn and the per-puncher
spawns.

### 2. `select_ok` dropped the reader on the resolver's success

The sender/reader pair used `select_ok`, which returns on the **first** `Ok` and
drops the rest. The resolver finishing first is the ordinary case, not an edge
one — it completes as soon as every local puncher has resolved, *including when
they all failed*. With the reader gone, a `Winner` the remote sends afterwards is
never consumed, `commanded_winner` is never set, and both sides sit until the
whole attempt times out. That is exactly the asymmetric-NAT recovery this
protocol exists for.

Now `futures::future::join`, so both stay polled. The arm still ends in
`pending()`; termination still belongs to the `select!` below, unchanged.

The **other** `select_ok` in this file is deliberately left alone, and now
carries a comment saying why: in the loser-rebuild race, "first socket wins and
the other attempt is abandoned" *is* the intended meaning.

### Controls

Each fix ships with its own control **as a test**, so neither can quietly stop
measuring:

- `a_bare_join_handle_detaches_instead` — pins that the runtime does not abort on
  drop by itself, so `dropping_the_handle_stops_the_task` is measuring the
  wrapper.
- `select_ok_would_have_dropped_the_reader` — pins that the combinator swap is
  what changed the outcome.

The `sender_reader_combo_tests` are honest about their reach: they pin the
*shape* of the combination, not the whole of `drive`, which would need two live
`NetworkEndpoint`s and a NAT.

`cargo test -p citadel_wire`: 36 pass. `cargo clippy -p citadel_wire --all-targets`: clean.