### PR TITLE
fix: the 5s force-clear stops the session instead of merely forgetting it

### DIFF
--- a/citadel_proto/src/proto/session_manager.rs
+++ b/citadel_proto/src/proto/session_manager.rs
@@ -261,7 +261,18 @@ impl<R: Ratchet, T: PlatformOps> CitadelSessionManager<R, T> {
             _ = timeout => {
                 citadel_logging::warn!(target: "citadel", "Session attempt for {cid} failed to disconnect within the timeout. Force clearing");
                 let mut this = inner_mut!(self);
-                this.sessions.remove(&cid);
+                // STOP it, do not merely forget it. Removing the map entry left
+                // the session's task running: a zombie that still holds peer
+                // vconns and whose own teardown fires later, by which time the
+                // replacement session owns that CID -- and that teardown is
+                // keyed only by CID.
+                if let Some((stopper, _zombie)) = this.sessions.remove(&cid) {
+                    // Err means nothing is subscribed, i.e. it has already shut
+                    // down. That is the good outcome, not a failure.
+                    if stopper.send(()).is_err() {
+                        citadel_logging::trace!(target: "citadel", "Force-cleared session {cid} had already stopped");
+                    }
+                }
                 this.provisional_connections.retain(|_, sess| sess.2.session_cid.get().unwrap_or(0) != cid);
                 this.provisional_cid_reservations.remove(&cid);
                 true


### PR DESCRIPTION
Two halves of one failure, both in `citadel_proto/src/proto/session_manager.rs`.

### 1. The safe-shutdown teardown never asked which incarnation it was

`execute_session_with_safe_shutdown` ends by walking the session's virtual
connections and reaching into **other** sessions' state containers — keyed only
by CID — to remove the vConn back to itself.

A lingering session (a cell-tower change, a WiFi↔cellular switch, or the
force-clear zombie below) shuts down *after* a reconnection has already taken the
CID. So the teardown deleted the vConns the **replacement** session had just
re-established, and the peer went quiet with nothing in the log but a
`Report to developers` warning.

The discriminator already exists and is already used **in the same call path**:
`clear_session` compares `init_time` and refuses to remove a map entry a
reconnection has since put there. The identical hazard was *also* already
recognised a few lines below, for `peer_kem_states` —

```rust
// NOTE: Do NOT remove peer_kem_states here — a new
// reconnection may have already inserted fresh KEM state.
```

— and fixed there only. `is_superseded` now states it once, so the teardown and
the map removal cannot disagree about which incarnation they are looking at.

Draining our **own** vconns still happens either way; that affects nobody else.
Only the parts that mutate another session are skipped.

### 2. The 5 s force-clear produced the zombie that runs it

`can_proceed_with_new_incoming_connection` waits up to 5 s for a disconnecting
session, then "force clears" by removing the map entry — and only that. The
session's task kept running, still holding peer vconns, and its own teardown
fired later, by which time the replacement owned the CID. It now signals the
stopper. `send` returning `Err` means nothing is subscribed, i.e. it has already
stopped, which is the good outcome and is logged at trace, not warn.

### Controls, and what is not covered

`is_superseded` is controlled by forcing it to `false`: the two superseded cases
go red and the two not-superseded cases correctly stay green, so the test
discriminates on the predicate rather than on its shape.

The force-clear half has **no test of its own**. Reaching it needs a session that
takes longer than five seconds to disconnect, which is a timing property of a
live protocol run rather than something a unit test can stage. It is a behaviour
change verified by reading, and I would rather say so than add a test that
exercises a different path and implies coverage it does not have.

`cargo test -p citadel_proto --lib`: 48 pass. `cargo clippy -p citadel_proto --all-targets`: clean.