### PR TITLE
fix: a rekey that never completes no longer wedges every rekey after it

### DIFF
--- a/citadel_crypt/src/ratchets/ratchet_manager.rs
+++ b/citadel_crypt/src/ratchets/ratchet_manager.rs
@@ -622,6 +622,23 @@ where
                 // This prevents indefinite blocking if the listener notification is missed
                 // (e.g., due to stale message skipping or rare race conditions).
                 const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+                // A ceiling on the whole wait, not just on one slice of it.
+                //
+                // The loop below used to `continue` forever whenever a slice
+                // timed out without the version advancing -- and it does that
+                // while still holding `_permit`, the single permit of
+                // `rekey_trigger_semaphore` acquired at the top of this
+                // function. So one rekey the peer never answers (it stale-skips
+                // our AliceToBob, for instance) wedged EVERY later rekey on the
+                // session, and in Perfect mode messaging waits on rekeys.
+                //
+                // 60s matches DECLARED_VERSION_STALENESS_TIMEOUT_SECS above,
+                // which is this file's existing answer to "how long before we
+                // call a rekey stuck". Failing here releases the permit and
+                // lets the next attempt run; the caller decides whether to
+                // retry.
+                const OVERALL_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+                let wait_deadline = citadel_io::time::Instant::now() + OVERALL_WAIT_TIMEOUT;
                 let mut rx = rx.unwrap();
                 loop {
                     match citadel_io::time::timeout(WAIT_TIMEOUT, &mut rx).await {
@@ -651,10 +668,17 @@ where
                                 self.cid, version_at_entry, current_version, rkt_start.elapsed().as_millis());
                                 break;
                             }
-                            // Version unchanged after timeout - log and continue waiting
+                            // Version unchanged after this slice. Keep waiting,
+                            // but not forever -- see OVERALL_WAIT_TIMEOUT.
+                            if citadel_io::time::Instant::now() >= wait_deadline {
+                                log::warn!(target: "citadel", "[CBD-RKT-WAIT] Client {} giving up on rekey after {}ms, version still {}; releasing the rekey semaphore",
+                                self.cid, rkt_start.elapsed().as_millis(), current_version);
+                                return Err(citadel_io::error!(
+                                    citadel_io::ErrorCode::RekeyMessageTimeout
+                                ));
+                            }
                             log::debug!(target: "citadel", "[CBD-RKT-WAIT] Client {} waiting for listener, version unchanged at {}: elapsed={}ms",
                             self.cid, current_version, rkt_start.elapsed().as_millis());
-                            // Continue looping - the rekey might still complete
                         }
                     }
                 }

--- a/citadel_proto/src/proto/state_container/mod.rs
+++ b/citadel_proto/src/proto/state_container/mod.rs
@@ -130,8 +130,8 @@ pub(crate) mod includes {
     // them via `use super::includes::*;`.
     pub(crate) use super::{
         EndpointChannelContainer, FileKey, GroupKey, GroupReceiverContainer, InboundFileTransfer,
-        P2PDisconnectSignal, ReKeyIndex, StateContainer, StateContainerInner,
-        UnorderedChannelContainer, VirtualConnection,
+        P2PDisconnectSignal, StateContainer, StateContainerInner, UnorderedChannelContainer,
+        VirtualConnection,
     };
 }
 
@@ -212,7 +212,16 @@ pub struct StateContainerInner<R: Ratchet> {
     pub(super) group_cgka: HashMap<MessageGroupKey, crate::proto::peer::group_cgka::GroupCgkaState>,
     pub(super) transfer_stats: TransferStats,
     pub(super) udp_mode: UdpMode,
-    triggered_rekeys: Arc<Mutex<HashMap<ReKeyIndex, Ticket>>>,
+    /// The rekey each target CID currently has in flight, by the ticket that
+    /// asked for it.
+    ///
+    /// Keyed by `target_cid` alone, because that is the only thing the
+    /// completion listener can match on — a rekey completion carries no ticket.
+    /// It used to be keyed by `(target_cid, ticket)`, which made the listener
+    /// pick an ARBITRARY entry for the CID out of hash order, and made the
+    /// duplicate check in `initiate_rekey` unable to fire at all: a `Ticket` is
+    /// unique per request, so `insert` never returned `Some`.
+    triggered_rekeys: Arc<Mutex<HashMap<u64, Ticket>>>,
     session_passwords: HashMap<u64, PreSharedKey>,
     is_server: bool,
 }
@@ -223,12 +232,6 @@ pub(crate) struct GroupKey {
     target_cid: u64,
     group_id: u64,
     object_id: ObjectId,
-}
-
-#[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]
-pub(crate) struct ReKeyIndex {
-    target_cid: u64,
-    ticket: Ticket,
 }
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq, Debug)]

--- a/citadel_proto/src/proto/state_container/rekey_and_groups.rs
+++ b/citadel_proto/src/proto/state_container/rekey_and_groups.rs
@@ -49,18 +49,39 @@ impl<R: Ratchet> StateContainerInner<R> {
             return return_already_in_progress(&self.kernel_tx, ticket, session_cid);
         }
 
-        // Insert into map
-        let index = ReKeyIndex { ticket, target_cid };
-
-        if self.triggered_rekeys.lock().insert(index, ticket).is_some() {
+        // Claim this target CID for the duration of the rekey.
+        //
+        // Keyed by target_cid alone. It used to be keyed by (target_cid,
+        // ticket), which made this check dead: a Ticket is unique per request,
+        // so `insert` never returned `Some` and the AlreadyInProgress branch
+        // was unreachable.
+        if self
+            .triggered_rekeys
+            .lock()
+            .insert(target_cid, ticket)
+            .is_some()
+        {
             return return_already_in_progress(&self.kernel_tx, ticket, session_cid);
         }
 
         let to_kernel = self.kernel_tx.clone();
+        let triggered_rekeys = self.triggered_rekeys.clone();
 
         let ratchet_manager = v_conn.ratchet_manager.clone();
         let task = async move {
             if let Err(err) = ratchet_manager.trigger_rekey(true).await {
+                // Release the claim on the FAILURE path too.
+                //
+                // It was only ever released by the completion listener, which
+                // runs on success. So one transient failure left an entry that
+                // never went away -- and the listener, matching on target_cid,
+                // then consumed it when a LATER rekey succeeded, reporting that
+                // success against the failed rekey's ticket. The ticket
+                // actually waiting heard nothing, and the SDK's `rekey()` hung
+                // on it. With the map keyed by target_cid this would instead
+                // wedge the CID permanently in AlreadyInProgress, which is why
+                // the two halves of this fix belong together.
+                triggered_rekeys.lock().remove(&target_cid);
                 if let Err(err) = to_kernel.unbounded_send(NodeResult::ReKeyResult(ReKeyResult {
                     ticket,
                     status: ReKeyReturnType::Failure { err },

--- a/citadel_proto/src/proto/state_container/virtual_connections.rs
+++ b/citadel_proto/src/proto/state_container/virtual_connections.rs
@@ -168,10 +168,12 @@ impl<R: Ratchet> StateContainerInner<R> {
         let task_rekey_finished_listener = async move {
             while let Some(rekey_finished) = rekey_rx.recv().await {
                 let mut lock = triggered_rekeys.lock();
-                if let Some(entry) = lock.iter().find(|r| r.0.target_cid == target_cid) {
-                    let ticket = *entry.1;
-                    let to_remove = *entry.0;
-                    lock.remove(&to_remove);
+                // An exact lookup, not a scan. The scan matched on target_cid
+                // and took whichever entry hash order produced, so with more
+                // than one entry for a CID -- which a leaked failure made
+                // ordinary -- a success could be reported against the wrong
+                // ticket.
+                if let Some(ticket) = lock.remove(&target_cid) {
                     let result = NodeResult::ReKeyResult(ReKeyResult {
                         ticket,
                         status: ReKeyReturnType::Success {


### PR DESCRIPTION
Three defects that compound into *automatic key rotation silently stops*.

### 1. `citadel_crypt` — the wait loop had no ceiling, and held the semaphore

`trigger_rekey(wait_for_completion=true)` acquires the single permit of
`rekey_trigger_semaphore` at the top of the function and holds it for the whole
body. The wait at the end sliced into 10 s timeouts, and on each slice with no
version advance it logged *"the rekey might still complete"* and looped again —
**forever**.

So one rekey the peer never answers (it stale-skips our `AliceToBob`, say)
wedged **every** later rekey on that session. In Perfect mode, messaging waits on
rekeys.

Now bounded by `OVERALL_WAIT_TIMEOUT` (60 s, matching
`DECLARED_VERSION_STALENESS_TIMEOUT_SECS` — this file's existing answer to "how
long before we call a rekey stuck"). Failing releases the permit; the caller
decides whether to retry.

### 2. `citadel_proto` — `triggered_rekeys` leaked on the failure path

The entry was inserted by `initiate_rekey` and removed only by the completion
listener, which runs on success. One transient failure left an entry that never
went away.

### 3. …and the listener then consumed it for the wrong ticket

```rust
if let Some(entry) = lock.iter().find(|r| r.0.target_cid == target_cid) {
```

An **arbitrary** entry for that CID, in hash order. With a leaked entry present
(ordinary, per 2), a *later* successful rekey reported its success against the
*failed* rekey's ticket. The ticket actually waiting heard nothing, and the SDK's
`rekey()` hung on it.

`triggered_rekeys` is now keyed by `target_cid` alone — the only thing a
completion can be matched on, since it carries no ticket — so the lookup is
exact, and the failure path releases the claim.

### A check that could not fire

That re-key also revives a dead check. `initiate_rekey`'s
`insert(index, ticket).is_some()` → `AlreadyInProgress` was **unreachable**: a
`Ticket` is unique per request and the index contained it, so `insert` never
returned `Some`. Keyed by `target_cid` it is a real duplicate check — which is
exactly why (2) had to be fixed in the same commit, or a leaked entry would now
wedge the CID in `AlreadyInProgress` instead of mis-reporting.

### Verification, and what is not covered

Verified end-to-end rather than by unit test: `rekey_messaging_test`,
`reconnection_c2s` and `stress_reconnect_c2s` all pass, and they drive this path.
`citadel_crypt` 75 and `citadel_proto` 44 lib tests pass; clippy clean on both.

The wedge itself has **no regression test**. Reproducing it needs a peer that
accepts an `AliceToBob` and never answers — a property of a live protocol run,
not something a unit test can stage. I would rather say that than add a test that
exercises a different path and implies coverage it does not have.