### PR TITLE
fix: a lingering session's teardown removes only the vConns it forged

### DIFF
--- a/citadel_proto/src/proto/packet_processor/peer/server/post_connect.rs
+++ b/citadel_proto/src/proto/packet_processor/peer/server/post_connect.rs
@@ -94,8 +94,11 @@ pub(crate) async fn handle_response_phase_post_connect<R: Ratchet, T: PlatformOp
                                           session_cid: target_cid,
                                           peer_cid: session_cid,
                                       };
-                                      this_sess_state_container.insert_new_virtual_connection_as_server(target_cid, virtual_conn_relative_to_this, peer_udp_sender, peer_tcp_sender);
-                                      peer_sess_state_container.insert_new_virtual_connection_as_server(session_cid, virtual_conn_relative_to_peer, this_udp_sender, this_tcp_sender);
+                                      // Each vConn records the incarnation of the session it points AT,
+                                      // so a lingering session's teardown can tell its own vConn from a
+                                      // replacement's. See VirtualConnection::peer_session_init_time.
+                                      this_sess_state_container.insert_new_virtual_connection_as_server(target_cid, virtual_conn_relative_to_this, peer_udp_sender, peer_tcp_sender, peer_sess.init_time);
+                                      peer_sess_state_container.insert_new_virtual_connection_as_server(session_cid, virtual_conn_relative_to_peer, this_udp_sender, this_tcp_sender, this_sess.init_time);
                                       log::trace!(target: "citadel", "Virtual connection between {session_cid} <-> {target_cid} forged");
                                       // TODO: Ensure that, upon disconnect, the corresponding entry gets dropped in the connection table of not the dropped peer
                                   }

--- a/citadel_proto/src/proto/session_manager.rs
+++ b/citadel_proto/src/proto/session_manager.rs
@@ -637,12 +637,52 @@ impl<R: Ratchet, T: PlatformOps> CitadelSessionManager<R, T> {
                                 if let Some(peer_sess) = sess_mgr.sessions.get(&peer_cid) {
                                     let peer_sess = &peer_sess.1;
                                     let mut peer_state_container = inner_mut_state!(peer_sess.state_container);
-                                    // Stop peer's UDP task before removing vconn
-                                    peer_state_container.remove_udp_channel(session_cid);
-                                    // NOTE: Do NOT remove peer_kem_states here — a new
-                                    // reconnection may have already inserted fresh KEM state.
-                                    if peer_state_container.active_virtual_connections.remove(&session_cid).is_none() {
-                                        log::warn!(target: "citadel", "While dropping session {session_cid}, attempted to remove vConn to {peer_cid}, but peer did not have the vConn listed. Report to developers");
+                                    // Remove the peer's vConn back to us ONLY if it is
+                                    // the one WE forged.
+                                    //
+                                    // `active_virtual_connections` is keyed by CID, and a
+                                    // CID outlives any one session: a cell-tower change or
+                                    // a WiFi/cellular switch leaves this session lingering
+                                    // while a replacement takes the same CID and
+                                    // re-establishes P2P. Removing by CID alone deleted
+                                    // whichever vConn was there -- including the
+                                    // replacement's, which the peer had just started using.
+                                    //
+                                    // The same hazard was already recognised for
+                                    // `peer_kem_states` on the very next line ("a new
+                                    // reconnection may have already inserted fresh KEM
+                                    // state") and fixed there only.
+                                    //
+                                    // Skipping the removal WHOLESALE whenever a replacement
+                                    // exists is not the fix -- that was tried, and it left
+                                    // genuinely dead vConns behind for the peer to use,
+                                    // which surfaces as an AEAD failure with a stale ratchet
+                                    // version. The vConn itself records which incarnation
+                                    // forged it, so this compares rather than guesses.
+                                    let forged_by_us = peer_state_container
+                                        .active_virtual_connections
+                                        .get(&session_cid)
+                                        .map(|vconn| match vconn.peer_session_init_time {
+                                            // Unstamped: a client-side vConn, or one forged
+                                            // before this field existed. Removing is the
+                                            // pre-existing behaviour and stays the default —
+                                            // this guard exists to spare a REPLACEMENT, and
+                                            // an unstamped vConn is not evidence of one.
+                                            None => true,
+                                            Some(forged_with) => forged_with == sess.init_time,
+                                        })
+                                        .unwrap_or(false);
+
+                                    if forged_by_us {
+                                        // Stop peer's UDP task before removing vconn
+                                        peer_state_container.remove_udp_channel(session_cid);
+                                        // NOTE: Do NOT remove peer_kem_states here — a new
+                                        // reconnection may have already inserted fresh KEM state.
+                                        if peer_state_container.active_virtual_connections.remove(&session_cid).is_none() {
+                                            log::warn!(target: "citadel", "While dropping session {session_cid}, attempted to remove vConn to {peer_cid}, but peer did not have the vConn listed. Report to developers");
+                                        }
+                                    } else {
+                                        log::info!(target: "citadel", "Leaving peer {peer_cid}'s vConn to {session_cid} intact: it was forged by a newer incarnation of that session, not by this one");
                                     }
                                 }
                             }

--- a/citadel_proto/src/proto/state_container/mod.rs
+++ b/citadel_proto/src/proto/state_container/mod.rs
@@ -330,6 +330,21 @@ pub struct VirtualConnection<R: Ratchet> {
     /// Used to build `DisconnectToken` for stale-signal rejection.
     /// `Ticket(0)` for C2S connections.
     pub p2p_connection_id: Ticket,
+    /// WHICH INCARNATION of the peer's session this vConn was forged with.
+    ///
+    /// `active_virtual_connections` is keyed by CID alone, and a CID outlives
+    /// any one session: a cell-tower change or a WiFi/cellular switch leaves a
+    /// lingering session while a replacement takes the same CID. When the
+    /// lingering one finally shuts down, its teardown reaches into the PEER's
+    /// state container and removes the vConn back to itself -- keyed only by
+    /// that CID, so it cannot tell its own vConn from the replacement's, and
+    /// deletes whichever is there.
+    ///
+    /// Recording the peer session's `init_time` at the moment the vConn is
+    /// forged makes that answerable. `None` on the client side, which never
+    /// performs this teardown; `Some` on the server, which does and which holds
+    /// both sessions when it forges the pair.
+    pub peer_session_init_time: Option<Instant>,
 }
 
 impl<R: Ratchet> VirtualConnection<R> {

--- a/citadel_proto/src/proto/state_container/virtual_connections.rs
+++ b/citadel_proto/src/proto/state_container/virtual_connections.rs
@@ -291,6 +291,9 @@ impl<R: Ratchet> StateContainerInner<R> {
             endpoint_container,
             adjacent_nat_type,
             p2p_connection_id,
+            // Client side: this node never runs the server's peer teardown, so
+            // there is no incarnation question to answer here.
+            peer_session_init_time: None,
         };
 
         // Guard: when both peers call connect_to_peer() simultaneously, two independent
@@ -323,12 +326,17 @@ impl<R: Ratchet> StateContainerInner<R> {
 
     /// Note: the `endpoint_crypto` container needs to be Some in order for transfer to occur between peers w/o encryption/decryption at the center point
     /// GROUP packets and PEER_CMD::CHANNEL packets bypass the central node's encryption/decryption phase
+    /// `peer_session_init_time` identifies WHICH incarnation of `target_cid`'s
+    /// session this vConn was forged with -- see the field. The server holds
+    /// both sessions at the moment it forges the pair, so it is the only place
+    /// that can answer it.
     pub fn insert_new_virtual_connection_as_server(
         &mut self,
         target_cid: u64,
         connection_type: VirtualConnectionType,
         target_udp_sender: Option<OutboundUdpSender>,
         target_tcp_sender: OutboundPrimaryStreamSender,
+        peer_session_init_time: Instant,
     ) {
         let val = VirtualConnection {
             last_delivered_message_timestamp: DualRwLock::from(None),
@@ -338,6 +346,7 @@ impl<R: Ratchet> StateContainerInner<R> {
             is_active: Arc::new(AtomicBool::new(true)),
             adjacent_nat_type: None, // Server doesn't have direct NAT info for clients
             p2p_connection_id: Ticket(0), // Server doesn't track P2P connection IDs
+            peer_session_init_time: Some(peer_session_init_time),
         };
         if self
             .active_virtual_connections


### PR DESCRIPTION
`active_virtual_connections` is keyed by CID, and **a CID outlives any one
session**. A cell-tower change or a WiFi↔cellular switch leaves a session
lingering while a replacement takes the same CID and re-establishes P2P. When the
lingering one finally shuts down, its teardown reaches into the **peer's** state
container and removes the vConn back to itself — keyed only by that CID, so it
cannot tell its own vConn from the replacement's and deletes whichever is there.
The peer goes quiet, with nothing in the log but a `Report to developers`
warning.

The same hazard was already recognised **on the very next line**, for
`peer_kem_states`:

```rust
// NOTE: Do NOT remove peer_kem_states here — a new
// reconnection may have already inserted fresh KEM state.
```

…and fixed there only.

### Why the obvious fix is wrong

Skipping the teardown **wholesale** whenever a replacement exists was the first
revision of #284. It turned `citadel_sdk (macos-latest)` red at
`reconnection_both_c2s.rs:439`:

```
AEAD decrypt_in_place failed
AES-GCM stage failed … Supplied Ratchet Version: 0 | Expected Ratchet Version: 1
```

because it left **genuinely dead** vConns behind for the peer to use. The
teardown is load-bearing for those. Only the replacement's must be spared.

### The fix

The vConn records **which incarnation forged it**, so the teardown compares
instead of guessing. The server holds *both* sessions at the moment it forges the
pair (`post_connect.rs`), so it is the only place that can answer the question —
and it answers it there.

- `None` on the client side, which never runs this teardown.
- An unstamped vConn is removed exactly as before: this guard exists to spare a
  **replacement**, and an unstamped vConn is not evidence of one.
- Server-internal only — **no wire format change, no migration**.

### Verification

`citadel_proto`: 44 lib tests. `reconnection_both_c2s` and
`reconnection_p2p_one_c2s` both pass locally. Native **and**
`wasm32-unknown-unknown` both compile — verified by running the wasm check, not
reasoned about, because the first attempt shipped a signature naming
`citadel_io::tokio::time::Instant` (which aliases the plain one on native and
does not on wasm) and CI caught it.

**The failure this replaces did not reproduce locally**, so macOS CI is the real
judge. If it reddens in the same place again, the hypothesis is wrong and this
should be withdrawn rather than patched.