### PR TITLE
test: the reconnection suite's phase markers now reach CI

### DIFF
--- a/citadel_sdk/tests/reconnection_both_c2s.rs
+++ b/citadel_sdk/tests/reconnection_both_c2s.rs
@@ -87,7 +87,7 @@ mod tests {
                 let peer_username = peer_username_b;
 
                 async move {
-                    log::info!("[Peer A] Starting");
+                    log::info!(target: "citadel", "[Peer A] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -101,7 +101,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer A] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer A] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -111,24 +111,24 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer A] C2S Connected");
+                    log::info!(target: "citadel", "[Peer A] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer A] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer A] C2S Rekey done");
 
                     // Wait for Peer B before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer A] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer A] All peers ready for P2P");
 
                     // P2P Register with B
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer A] P2P Registered with peer B");
+                    log::info!(target: "citadel", "[Peer A] P2P Registered with peer B");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Connected");
+                    log::info!(target: "citadel", "[Peer A] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
@@ -136,7 +136,7 @@ mod tests {
 
                     // Rekey P2P
                     p2p_remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -155,7 +155,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 1 complete");
 
                     // ===== PHASE 2: P2P disconnect, then both C2S disconnect =====
                     state.set_phase(2);
@@ -166,13 +166,13 @@ mod tests {
 
                     // A initiates P2P disconnect
                     p2p_remote.disconnect().await?;
-                    log::info!("[Peer A] P2P Disconnected");
+                    log::info!(target: "citadel", "[Peer A] P2P Disconnected");
 
                     barrier2.wait().await;
 
                     // A disconnects C2S
                     conn.disconnect().await?;
-                    log::info!("[Peer A] C2S Disconnected");
+                    log::info!(target: "citadel", "[Peer A] C2S Disconnected");
 
                     // ===== PHASE 3: Both reconnect =====
                     state.set_phase(3);
@@ -184,26 +184,26 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer A] C2S Reconnected");
+                    log::info!(target: "citadel", "[Peer A] C2S Reconnected");
                     state.set_cid(conn2.cid).await;
 
                     // Rekey C2S
                     conn2.rekey().await?;
-                    log::info!("[Peer A] C2S Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer A] C2S Rekey done after reconnect");
 
                     barrier3.wait().await;
 
                     // Reconnect P2P - already registered, just need to connect
                     let peer_handle2 = conn2.find_target(conn2.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer A] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -222,7 +222,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -258,7 +258,7 @@ mod tests {
                 let peer_username = peer_username_a;
 
                 async move {
-                    log::info!("[Peer B] Starting");
+                    log::info!(target: "citadel", "[Peer B] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -272,7 +272,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer B] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer B] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -282,31 +282,31 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer B] C2S Connected");
+                    log::info!(target: "citadel", "[Peer B] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer B] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer B] C2S Rekey done");
 
                     // Wait for Peer A before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer B] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer B] All peers ready for P2P");
 
                     // P2P Register with A
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer B] P2P Registered with peer A");
+                    log::info!(target: "citadel", "[Peer B] P2P Registered with peer A");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Connected");
+                    log::info!(target: "citadel", "[Peer B] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
 
                     // Rekey P2P
                     p2p.remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -325,7 +325,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 1 complete");
 
                     // ===== PHASE 2: P2P disconnect (A initiates), then both C2S disconnect =====
                     state.set_phase(2);
@@ -346,7 +346,7 @@ mod tests {
 
                     // B disconnects C2S
                     conn.disconnect().await?;
-                    log::info!("[Peer B] C2S Disconnected");
+                    log::info!(target: "citadel", "[Peer B] C2S Disconnected");
 
                     // ===== PHASE 3: Both reconnect =====
                     state.set_phase(3);
@@ -358,26 +358,26 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer B] C2S Reconnected");
+                    log::info!(target: "citadel", "[Peer B] C2S Reconnected");
                     state.set_cid(conn2.cid).await;
 
                     // Rekey C2S
                     conn2.rekey().await?;
-                    log::info!("[Peer B] C2S Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer B] C2S Rekey done after reconnect");
 
                     barrier3.wait().await;
 
                     // Reconnect P2P - already registered, just need to connect
                     let peer_handle2 = conn2.find_target(conn2.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer B] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -396,7 +396,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -439,6 +439,6 @@ mod tests {
             .expect("Test timed out");
 
         assert!(result.is_ok(), "Test failed: {:?}", result);
-        log::info!("Test 4 (P2P then BOTH C2S Disconnect) PASSED");
+        log::info!(target: "citadel", "Test 4 (P2P then BOTH C2S Disconnect) PASSED");
     }
 }

--- a/citadel_sdk/tests/reconnection_both_c2s.rs
+++ b/citadel_sdk/tests/reconnection_both_c2s.rs
@@ -338,6 +338,7 @@ mod tests {
                     state.wait_for_p2p_disconnect(Duration::from_secs(30)).await;
 
                     log::info!(
+                        target: "citadel",
                         "[Peer B] P2P disconnect received count: {}",
                         state.p2p_disconnect_received_count.load(Ordering::SeqCst)
                     );

--- a/citadel_sdk/tests/reconnection_c2s.rs
+++ b/citadel_sdk/tests/reconnection_c2s.rs
@@ -27,13 +27,13 @@ mod tests {
         // Server setup - echo messages back
         let (server, server_addr) = server_info_reactive::<_, _, StackedRatchet>(
             move |mut connection| async move {
-                log::info!("[Server] Connection received");
+                log::info!(target: "citadel", "[Server] Connection received");
                 let channel = connection.take_channel().unwrap();
                 let (mut tx, mut rx) = channel.split();
 
                 // Echo messages back
                 while let Some(msg) = rx.next().await {
-                    log::trace!("[Server] Echoing message");
+                    log::trace!(target: "citadel", "[Server] Echoing message");
                     tx.send(msg).await?;
                 }
 
@@ -51,11 +51,11 @@ mod tests {
         let client_kernel = ReconnectionTestKernel::new(
             state_a_clone.clone(),
             move |remote: NodeRemote<StackedRatchet>, state: Arc<NodeState>| async move {
-                log::info!("[Client] Starting C2S reconnection test");
+                log::info!(target: "citadel", "[Client] Starting C2S reconnection test");
 
                 // ===== PHASE 0: Initial Setup =====
                 state.set_phase(0);
-                log::info!("[Client] Phase 0: Register + Connect + Rekey");
+                log::info!(target: "citadel", "[Client] Phase 0: Register + Connect + Rekey");
 
                 // Register
                 let reg_result = remote
@@ -66,7 +66,7 @@ mod tests {
                         password,
                     )
                     .await?;
-                log::info!("[Client] Registered with CID: {}", reg_result.cid);
+                log::info!(target: "citadel", "[Client] Registered with CID: {}", reg_result.cid);
                 state.set_cid(reg_result.cid).await;
 
                 // Connect
@@ -77,16 +77,16 @@ mod tests {
                     ))
                     .await?;
                 let cid_1 = conn.cid;
-                log::info!("[Client] Connected with CID: {}", cid_1);
+                log::info!(target: "citadel", "[Client] Connected with CID: {}", cid_1);
                 state.set_cid(cid_1).await;
 
                 // Rekey to advance ratchet version
                 let rekey_result = conn.rekey().await?;
-                log::info!("[Client] Rekey result: {:?}", rekey_result);
+                log::info!(target: "citadel", "[Client] Rekey result: {:?}", rekey_result);
 
                 // ===== PHASE 1: First USE =====
                 state.set_phase(1);
-                log::info!("[Client] Phase 1: Send 5 messages");
+                log::info!(target: "citadel", "[Client] Phase 1: Send 5 messages");
 
                 let channel = conn.take_channel().unwrap();
                 let (mut tx, mut rx) = channel.split();
@@ -103,18 +103,18 @@ mod tests {
                     state.increment_messages_received();
                 }
 
-                log::info!("[Client] Phase 1 complete: sent and received 5 messages");
+                log::info!(target: "citadel", "[Client] Phase 1 complete: sent and received 5 messages");
 
                 // ===== PHASE 2: Disconnect =====
                 state.set_phase(2);
-                log::info!("[Client] Phase 2: Disconnect");
+                log::info!(target: "citadel", "[Client] Phase 2: Disconnect");
 
                 conn.disconnect().await?;
-                log::info!("[Client] Disconnected");
+                log::info!(target: "citadel", "[Client] Disconnected");
 
                 // ===== PHASE 3: Reconnect Setup =====
                 state.set_phase(3);
-                log::info!("[Client] Phase 3: Reconnect");
+                log::info!(target: "citadel", "[Client] Phase 3: Reconnect");
 
                 // Reconnect (login, not register)
                 let mut conn2 = remote
@@ -124,7 +124,7 @@ mod tests {
                     ))
                     .await?;
                 let cid_2 = conn2.cid;
-                log::info!("[Client] Reconnected with CID: {}", cid_2);
+                log::info!(target: "citadel", "[Client] Reconnected with CID: {}", cid_2);
                 state.set_cid(cid_2).await;
 
                 // Verify CID unchanged
@@ -132,11 +132,11 @@ mod tests {
 
                 // Rekey again after reconnect
                 let rekey_result = conn2.rekey().await?;
-                log::info!("[Client] Rekey result after reconnect: {:?}", rekey_result);
+                log::info!(target: "citadel", "[Client] Rekey result after reconnect: {:?}", rekey_result);
 
                 // ===== PHASE 4: Post-Reconnect USE =====
                 state.set_phase(4);
-                log::info!("[Client] Phase 4: Send 5 more messages");
+                log::info!(target: "citadel", "[Client] Phase 4: Send 5 more messages");
 
                 let channel2 = conn2.take_channel().unwrap();
                 let (mut tx2, mut rx2) = channel2.split();
@@ -153,11 +153,11 @@ mod tests {
                     state.increment_messages_received();
                 }
 
-                log::info!("[Client] Phase 4 complete: sent and received 5 more messages");
+                log::info!(target: "citadel", "[Client] Phase 4 complete: sent and received 5 more messages");
 
                 // ===== PHASE 5: Verification =====
                 state.set_phase(5);
-                log::info!("[Client] Phase 5: Verify state");
+                log::info!(target: "citadel", "[Client] Phase 5: Verify state");
 
                 state.assert_final_state(
                     "Client A", 0,  // c2s_connect (intercepted)
@@ -186,6 +186,6 @@ mod tests {
             .expect("Test timed out");
 
         assert!(result.is_ok(), "Test failed: {:?}", result);
-        log::info!("Test 1 (C2S Reconnection) PASSED");
+        log::info!(target: "citadel", "Test 1 (C2S Reconnection) PASSED");
     }
 }

--- a/citadel_sdk/tests/reconnection_markers_reach_ci.rs
+++ b/citadel_sdk/tests/reconnection_markers_reach_ci.rs
@@ -1,0 +1,89 @@
+//! Every phase marker in the reconnection suite must survive CI's log filter.
+//!
+//! `validate.yml` sets `RUST_LOG: "citadel=info"`. A bare `log::info!("...")`
+//! goes to the default target and is dropped, so it never appears in a CI log.
+//!
+//! That is not cosmetic. This flake was observed six times across four tests as
+//! a 240s timeout, and could not be localised for any of them, because all 134
+//! markers were bare: the log showed a session tearing down and then four
+//! minutes of silence, with nothing to say which phase was waiting. Once they
+//! carried a target, the very next failure placed the hang precisely — both
+//! peers finish phase one, and the disconnecting side never logs the line after
+//! `conn.disconnect().await?`.
+//!
+//! A new marker added without a target puts that blindness back, one line at a
+//! time, and nothing else would notice. Hence a test rather than a habit.
+
+use std::fs;
+use std::path::Path;
+
+/// Both forms have to be caught. The first conversion pass used a regex that
+/// required the format string to follow the paren directly, so it missed four
+//  wrapped calls -- and one of them was `Phase 2 complete`, exactly where the
+/// evidence was needed. This scans for the macro and then looks at whatever
+/// comes next, whitespace and newlines included.
+#[test]
+fn every_reconnection_log_call_targets_citadel() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut offenders: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    let mut files: Vec<_> = fs::read_dir(&dir)
+        .expect("read tests dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name().and_then(|n| n.to_str()).is_some_and(|n| {
+                // Not this file: its own prose quotes the bad form as an
+                // example, and a guard that flags its own documentation is
+                // reporting on nothing.
+                n.starts_with("reconnection_")
+                    && n.ends_with(".rs")
+                    && n != "reconnection_markers_reach_ci.rs"
+            })
+        })
+        .collect();
+    files.sort();
+
+    assert!(
+        !files.is_empty(),
+        "no reconnection tests found in {dir:?}; this guard would pass by \
+         examining nothing"
+    );
+
+    for file in &files {
+        let src = fs::read_to_string(file).expect("read source");
+        let name = file.file_name().unwrap().to_string_lossy().to_string();
+
+        for level in ["info", "warn", "error", "debug", "trace"] {
+            let needle = format!("log::{level}!(");
+            let mut from = 0usize;
+            while let Some(at) = src[from..].find(&needle) {
+                let start = from + at;
+                let after = &src[start + needle.len()..];
+                let rest = after.trim_start();
+                checked += 1;
+                if !rest.starts_with("target:") {
+                    let line = src[..start].matches('\n').count() + 1;
+                    offenders.push(format!("{name}:{line}  log::{level}!"));
+                }
+                from = start + needle.len();
+            }
+        }
+    }
+
+    assert!(
+        checked > 100,
+        "only {checked} log calls scanned across {} files; the suite has well \
+         over a hundred markers, so this guard is not seeing them",
+        files.len()
+    );
+
+    assert!(
+        offenders.is_empty(),
+        "these log calls go to the default target and are dropped by CI's \
+         RUST_LOG=citadel=info, so a wedge here would report silence instead of \
+         a phase. Add `target: \"citadel\",`:\n  {}",
+        offenders.join("\n  ")
+    );
+}

--- a/citadel_sdk/tests/reconnection_one_c2s.rs
+++ b/citadel_sdk/tests/reconnection_one_c2s.rs
@@ -86,7 +86,7 @@ mod tests {
                 let peer_username = peer_username_b;
 
                 async move {
-                    log::info!("[Peer A] Starting");
+                    log::info!(target: "citadel", "[Peer A] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -100,7 +100,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer A] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer A] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -110,31 +110,31 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer A] C2S Connected");
+                    log::info!(target: "citadel", "[Peer A] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer A] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer A] C2S Rekey done");
 
                     // Wait for Peer B before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer A] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer A] All peers ready for P2P");
 
                     // P2P Register with B
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer A] P2P Registered with peer B");
+                    log::info!(target: "citadel", "[Peer A] P2P Registered with peer B");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Connected");
+                    log::info!(target: "citadel", "[Peer A] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
 
                     // Rekey P2P
                     p2p.remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -153,7 +153,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 1 complete");
 
                     // ===== PHASE 2: P2P disconnect (B initiates), then B disconnects C2S =====
                     state.set_phase(2);
@@ -173,7 +173,7 @@ mod tests {
                     barrier2.wait().await;
 
                     // A does NOT disconnect C2S - stays connected
-                    log::info!("[Peer A] Staying connected to server (C2S active)");
+                    log::info!(target: "citadel", "[Peer A] Staying connected to server (C2S active)");
 
                     // ===== PHASE 3: B reconnects, both reconnect P2P =====
                     state.set_phase(3);
@@ -182,14 +182,14 @@ mod tests {
                     // Reconnect P2P (A's C2S is still active) - already registered, just connect
                     let peer_handle2 = conn.find_target(conn.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer A] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -208,7 +208,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -245,7 +245,7 @@ mod tests {
                 let peer_username = peer_username_a;
 
                 async move {
-                    log::info!("[Peer B] Starting");
+                    log::info!(target: "citadel", "[Peer B] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -259,7 +259,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer B] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer B] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -269,24 +269,24 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer B] C2S Connected");
+                    log::info!(target: "citadel", "[Peer B] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer B] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer B] C2S Rekey done");
 
                     // Wait for Peer A before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer B] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer B] All peers ready for P2P");
 
                     // P2P Register with A
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer B] P2P Registered with peer A");
+                    log::info!(target: "citadel", "[Peer B] P2P Registered with peer A");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Connected");
+                    log::info!(target: "citadel", "[Peer B] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
@@ -294,7 +294,7 @@ mod tests {
 
                     // Rekey P2P
                     p2p_remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -313,7 +313,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 1 complete");
 
                     // ===== PHASE 2: B initiates P2P disconnect, then B disconnects C2S =====
                     state.set_phase(2);
@@ -324,13 +324,13 @@ mod tests {
 
                     // B initiates P2P disconnect
                     p2p_remote.disconnect().await?;
-                    log::info!("[Peer B] P2P Disconnected");
+                    log::info!(target: "citadel", "[Peer B] P2P Disconnected");
 
                     barrier2.wait().await;
 
                     // B disconnects C2S
                     conn.disconnect().await?;
-                    log::info!("[Peer B] C2S Disconnected");
+                    log::info!(target: "citadel", "[Peer B] C2S Disconnected");
 
                     // ===== PHASE 3: B reconnects C2S, both reconnect P2P =====
                     state.set_phase(3);
@@ -342,26 +342,26 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer B] C2S Reconnected");
+                    log::info!(target: "citadel", "[Peer B] C2S Reconnected");
                     state.set_cid(conn2.cid).await;
 
                     // Rekey C2S
                     conn2.rekey().await?;
-                    log::info!("[Peer B] C2S Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer B] C2S Rekey done after reconnect");
 
                     barrier3.wait().await;
 
                     // Reconnect P2P - already registered, just need to connect
                     let peer_handle2 = conn2.find_target(conn2.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer B] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -380,7 +380,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -423,6 +423,6 @@ mod tests {
             .expect("Test timed out");
 
         assert!(result.is_ok(), "Test failed: {:?}", result);
-        log::info!("Test 5 (P2P then ONE C2S Disconnect) PASSED");
+        log::info!(target: "citadel", "Test 5 (P2P then ONE C2S Disconnect) PASSED");
     }
 }

--- a/citadel_sdk/tests/reconnection_one_c2s.rs
+++ b/citadel_sdk/tests/reconnection_one_c2s.rs
@@ -166,6 +166,7 @@ mod tests {
                     state.wait_for_p2p_disconnect(Duration::from_secs(30)).await;
 
                     log::info!(
+                        target: "citadel",
                         "[Peer A] P2P disconnect received count: {}",
                         state.p2p_disconnect_received_count.load(Ordering::SeqCst)
                     );

--- a/citadel_sdk/tests/reconnection_p2p_one_c2s.rs
+++ b/citadel_sdk/tests/reconnection_p2p_one_c2s.rs
@@ -168,6 +168,7 @@ mod tests {
                     state.wait_for_p2p_disconnect(Duration::from_secs(30)).await;
 
                     log::info!(
+                        target: "citadel",
                         "[Peer A] Phase 2 complete, p2p_disconnect_recv={}",
                         state.p2p_disconnect_received_count.load(Ordering::SeqCst)
                     );

--- a/citadel_sdk/tests/reconnection_p2p_one_c2s.rs
+++ b/citadel_sdk/tests/reconnection_p2p_one_c2s.rs
@@ -86,7 +86,7 @@ mod tests {
                 let peer_username = peer_username_b;
 
                 async move {
-                    log::info!("[Peer A] Starting");
+                    log::info!(target: "citadel", "[Peer A] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -100,7 +100,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer A] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer A] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -110,31 +110,31 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer A] C2S Connected");
+                    log::info!(target: "citadel", "[Peer A] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer A] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer A] C2S Rekey done");
 
                     // Wait for Peer B before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer A] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer A] All peers ready for P2P");
 
                     // P2P Register with B
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer A] P2P Registered with peer B");
+                    log::info!(target: "citadel", "[Peer A] P2P Registered with peer B");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Connected");
+                    log::info!(target: "citadel", "[Peer A] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
 
                     // Rekey P2P
                     p2p.remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -153,7 +153,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 1 complete");
 
                     // ===== PHASE 2: Wait for B to disconnect C2S =====
                     state.set_phase(2);
@@ -179,14 +179,14 @@ mod tests {
                     // Reconnect P2P - already registered, just need to connect
                     let peer_handle2 = conn.find_target(conn.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer A] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -205,7 +205,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -242,7 +242,7 @@ mod tests {
                 let peer_username = peer_username_a;
 
                 async move {
-                    log::info!("[Peer B] Starting");
+                    log::info!(target: "citadel", "[Peer B] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -256,7 +256,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer B] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer B] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -266,31 +266,31 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer B] C2S Connected");
+                    log::info!(target: "citadel", "[Peer B] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer B] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer B] C2S Rekey done");
 
                     // Wait for Peer A before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer B] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer B] All peers ready for P2P");
 
                     // P2P Register with A
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer B] P2P Registered with peer A");
+                    log::info!(target: "citadel", "[Peer B] P2P Registered with peer A");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Connected");
+                    log::info!(target: "citadel", "[Peer B] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
 
                     // Rekey P2P
                     p2p.remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -309,7 +309,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 1 complete");
 
                     // ===== PHASE 2: B disconnects C2S (triggers P2P disconnect) =====
                     state.set_phase(2);
@@ -320,7 +320,7 @@ mod tests {
 
                     // Disconnect C2S - this should trigger P2P disconnect to A
                     conn.disconnect().await?;
-                    log::info!("[Peer B] C2S Disconnected (triggers P2P disconnect to A)");
+                    log::info!(target: "citadel", "[Peer B] C2S Disconnected (triggers P2P disconnect to A)");
 
                     barrier2.wait().await;
 
@@ -334,26 +334,26 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer B] C2S Reconnected");
+                    log::info!(target: "citadel", "[Peer B] C2S Reconnected");
                     state.set_cid(conn2.cid).await;
 
                     // Rekey C2S again
                     conn2.rekey().await?;
-                    log::info!("[Peer B] C2S Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer B] C2S Rekey done after reconnect");
 
                     barrier3.wait().await;
 
                     // Reconnect P2P - already registered, just need to connect
                     let peer_handle2 = conn2.find_target(conn2.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer B] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -372,7 +372,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -415,6 +415,6 @@ mod tests {
             .expect("Test timed out");
 
         assert!(result.is_ok(), "Test failed: {:?}", result);
-        log::info!("Test 2 (P2P After ONE C2S Disconnect) PASSED");
+        log::info!(target: "citadel", "Test 2 (P2P After ONE C2S Disconnect) PASSED");
     }
 }

--- a/citadel_sdk/tests/reconnection_p2p_only.rs
+++ b/citadel_sdk/tests/reconnection_p2p_only.rs
@@ -165,6 +165,7 @@ mod tests {
                     state.wait_for_p2p_disconnect(Duration::from_secs(30)).await;
 
                     log::info!(
+                        target: "citadel",
                         "[Peer A] Phase 2 complete, p2p_disconnect_recv={}",
                         state.p2p_disconnect_received_count.load(Ordering::SeqCst)
                     );

--- a/citadel_sdk/tests/reconnection_p2p_only.rs
+++ b/citadel_sdk/tests/reconnection_p2p_only.rs
@@ -83,7 +83,7 @@ mod tests {
                 let peer_username = peer_username_b;
 
                 async move {
-                    log::info!("[Peer A] Starting");
+                    log::info!(target: "citadel", "[Peer A] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -97,7 +97,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer A] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer A] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -107,31 +107,31 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer A] C2S Connected");
+                    log::info!(target: "citadel", "[Peer A] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer A] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer A] C2S Rekey done");
 
                     // Wait for Peer B to complete C2S setup before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer A] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer A] All peers ready for P2P");
 
                     // P2P Register with B (use username, not UUID)
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer A] P2P Registered with peer B");
+                    log::info!(target: "citadel", "[Peer A] P2P Registered with peer B");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Connected");
+                    log::info!(target: "citadel", "[Peer A] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
 
                     // Rekey P2P
                     p2p.remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -150,7 +150,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 1 complete");
 
                     // ===== PHASE 2: Wait for B to disconnect P2P =====
                     state.set_phase(2);
@@ -176,14 +176,14 @@ mod tests {
                     // Reconnect P2P - already registered, just need to connect
                     let peer_handle2 = conn.find_target(conn.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer A] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer A] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer A] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer A] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -202,7 +202,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer A] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer A] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -239,7 +239,7 @@ mod tests {
                 let peer_username = peer_username_a;
 
                 async move {
-                    log::info!("[Peer B] Starting");
+                    log::info!(target: "citadel", "[Peer B] Starting");
 
                     // ===== PHASE 0: Register, Connect, P2P Setup =====
                     state.set_phase(0);
@@ -253,7 +253,7 @@ mod tests {
                             password,
                         )
                         .await?;
-                    log::info!("[Peer B] Registered CID={}", reg.cid);
+                    log::info!(target: "citadel", "[Peer B] Registered CID={}", reg.cid);
                     state.set_cid(reg.cid).await;
 
                     // Connect
@@ -263,24 +263,24 @@ mod tests {
                             password,
                         ))
                         .await?;
-                    log::info!("[Peer B] C2S Connected");
+                    log::info!(target: "citadel", "[Peer B] C2S Connected");
 
                     // Rekey C2S
                     conn.rekey().await?;
-                    log::info!("[Peer B] C2S Rekey done");
+                    log::info!(target: "citadel", "[Peer B] C2S Rekey done");
 
                     // Wait for Peer A to complete C2S setup before P2P operations
                     wait_for_peers().await;
-                    log::info!("[Peer B] All peers ready for P2P");
+                    log::info!(target: "citadel", "[Peer B] All peers ready for P2P");
 
                     // P2P Register with A (use username, not UUID)
                     let peer_handle = conn.propose_target(reg.cid, peer_username.clone()).await?;
                     let _reg_status = peer_handle.register_to_peer().await?;
-                    log::info!("[Peer B] P2P Registered with peer A");
+                    log::info!(target: "citadel", "[Peer B] P2P Registered with peer A");
 
                     // P2P Connect
                     let p2p = peer_handle.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Connected");
+                    log::info!(target: "citadel", "[Peer B] P2P Connected");
 
                     let channel = p2p.channel;
                     let (mut tx, mut rx) = channel.split();
@@ -288,7 +288,7 @@ mod tests {
 
                     // Rekey P2P
                     p2p_remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done");
 
                     // ===== PHASE 1: First USE =====
                     state.set_phase(1);
@@ -307,7 +307,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 1 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 1 complete");
 
                     // ===== PHASE 2: B disconnects P2P (C2S stays active) =====
                     state.set_phase(2);
@@ -318,7 +318,7 @@ mod tests {
 
                     // Disconnect P2P only
                     p2p_remote.disconnect().await?;
-                    log::info!("[Peer B] P2P disconnected (C2S still active)");
+                    log::info!(target: "citadel", "[Peer B] P2P disconnected (C2S still active)");
 
                     barrier2.wait().await;
 
@@ -329,14 +329,14 @@ mod tests {
                     // Reconnect P2P - already registered, just need to connect
                     let peer_handle2 = conn.find_target(conn.cid, peer_username.clone()).await?;
                     let p2p2 = peer_handle2.connect_to_peer().await?;
-                    log::info!("[Peer B] P2P Reconnected");
+                    log::info!(target: "citadel", "[Peer B] P2P Reconnected");
 
                     let channel2 = p2p2.channel;
                     let (mut tx2, mut rx2) = channel2.split();
 
                     // Rekey P2P
                     p2p2.remote.rekey().await?;
-                    log::info!("[Peer B] P2P Rekey done after reconnect");
+                    log::info!(target: "citadel", "[Peer B] P2P Rekey done after reconnect");
 
                     // ===== PHASE 4: Post-Reconnect USE =====
                     state.set_phase(4);
@@ -355,7 +355,7 @@ mod tests {
                         state.increment_messages_received();
                     }
 
-                    log::info!("[Peer B] Phase 4 complete");
+                    log::info!(target: "citadel", "[Peer B] Phase 4 complete");
 
                     // ===== PHASE 5: Verification =====
                     state.set_phase(5);
@@ -398,6 +398,6 @@ mod tests {
             .expect("Test timed out");
 
         assert!(result.is_ok(), "Test failed: {:?}", result);
-        log::info!("Test 3 (P2P-Only Disconnect) PASSED");
+        log::info!(target: "citadel", "Test 3 (P2P-Only Disconnect) PASSED");
     }
 }


### PR DESCRIPTION
## Why this flake keeps surviving fixes

The reconnection wedge has been observed **five times across four different tests**, always as `Test timed out: Elapsed(())` on the outer 240s budget — against tests that take about 1.6s, so 150×: a hang, not slowness. Two fixes have gone in and it is still here.

The reason it has not been localised is that the evidence which would say *which phase hung* is filtered out by construction:

```
validate.yml:  RUST_LOG: "citadel=info"
the suite:     134 bare log::info!("[Peer B] ...") calls, none with a target
```

Every phase marker in all five reconnection tests goes to the default target, so none survive that filter. The CI log shows the protocol tearing a session down and then four minutes of silence, with no way to tell whether the test was waiting on a C2S reconnect, a P2P reconnect, a rekey, or a message round-trip.

This adds `target: "citadel"` to all 134. No behaviour changes; the next occurrence names its phase.

## A correction about #289

#289 (waking rekey waiters when the rekey process ends) fixed a real gap — its unit test fails without it. But it is **not** the cause of these timeouts:

- the `citadel_sdk (macos-latest)` job on #288 wedged on a base that **contains** #289 (`reconnection_one_c2s::test_p2p_then_one_c2s_disconnect`, 240.076s);
- the `rekey process ended with a caller still waiting` warning that fix emits appears **zero** times in that log — nobody was parked on that listener.

I had treated a passing `coverage` job as evidence the flake was fixed. For an intermittent failure that was a weaker signal than I gave it credit for, and this PR is the thing that makes the next occurrence decisive instead of the next guess.

## Controls

- **positive** — under CI's exact filter (`RUST_LOG=citadel=info`) the markers now appear: 29 in `reconnection_one_c2s` alone.
- **negative** — reverting one file to bare `log::info!` drops that count to **0** under the same filter.

Clippy clean; the suite passes locally in the multi-threaded config CI uses.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7