### PR TITLE
fix: a C2S disconnect can no longer wait for ever

### DIFF
--- a/citadel_sdk/src/remote_ext.rs
+++ b/citadel_sdk/src/remote_ext.rs
@@ -1112,19 +1112,53 @@ pub trait ProtocolRemoteTargetExt<R: Ratchet>: TargetLockedRemote<R> {
                 NodeRequest::DisconnectFromHypernode(DisconnectFromHypernode { session_cid: cid });
 
             let mut subscription = self.remote().send_callback_subscription(request).await?;
-            while let Some(event) = subscription.next().await {
-                if let NodeResult::Disconnect(Disconnect {
-                    success, message, ..
-                }) = event.into_result()?
-                {
-                    return if success {
-                        Ok(())
-                    } else {
-                        Err(citadel_io::error!(
-                            citadel_io::ErrorCode::RemoteDisconnected,
-                            message
+            // Bounded, because this wait is otherwise the end of the line.
+            //
+            // The stream closing is handled below, but a subscription that
+            // stays OPEN and simply never carries the matching Disconnect
+            // parks here for ever. That is the reconnection suite's 240s
+            // timeout: with the phase markers reaching CI, both peers finish
+            // phase one and the disconnecting side never logs the line after
+            // this call, while the other blocks on the barrier it never
+            // reaches. The only await between those two markers is this one.
+            //
+            // The session is being torn down either way, so an unconfirmed
+            // disconnect is reported rather than waited on: a caller can retry
+            // or proceed, and neither is possible from inside an indefinite
+            // await.
+            const DISCONNECT_CONFIRMATION_TIMEOUT: Duration = Duration::from_secs(30);
+            let deadline = citadel_io::time::Instant::now() + DISCONNECT_CONFIRMATION_TIMEOUT;
+            loop {
+                let remaining =
+                    deadline.saturating_duration_since(citadel_io::time::Instant::now());
+                if remaining.is_zero() {
+                    return Err(citadel_io::error!(
+                        citadel_io::ErrorCode::RemoteDisconnectEventMissing
+                    ));
+                }
+                match citadel_io::time::timeout(remaining, subscription.next()).await {
+                    Ok(Some(event)) => {
+                        if let NodeResult::Disconnect(Disconnect {
+                            success, message, ..
+                        }) = event.into_result()?
+                        {
+                            return if success {
+                                Ok(())
+                            } else {
+                                Err(citadel_io::error!(
+                                    citadel_io::ErrorCode::RemoteDisconnected,
+                                    message
+                                ))
+                            };
+                        }
+                    }
+                    // The stream ended without ever carrying the event.
+                    Ok(None) => break,
+                    Err(_elapsed) => {
+                        return Err(citadel_io::error!(
+                            citadel_io::ErrorCode::RemoteDisconnectEventMissing
                         ))
-                    };
+                    }
                 }
             }
 


### PR DESCRIPTION
## Where the reconnection wedge actually is

`disconnect()`'s C2S branch awaited its confirmation with an unbounded loop:

```rust
while let Some(event) = subscription.next().await { ... }
```

A closed stream is handled. A subscription that stays **open** and never carries the matching `Disconnect` is not — it parks there indefinitely.

That is where the suite's 240s timeout lives. With the phase markers now reaching CI (#290), the wedged run finally says where it stops:

- both peers complete phase one in full — register → C2S connect → C2S rekey → P2P register → P2P connect → P2P rekey;
- the disconnecting side never logs the line immediately after `conn.disconnect().await?`;
- the other side blocks for ever on the barrier it never reaches.

**The only await between those two markers is this call**, and the only unbounded await inside it is this loop.

## The fix

Bounded at 30s. The session is being torn down either way, so an unconfirmed disconnect is reported as `RemoteDisconnectEventMissing` — the error this function *already* returns when the stream ends without the event — rather than waited on. A caller can retry or proceed; neither is possible from inside an indefinite await.

## On evidence, and being straight about it

- **Localisation is solid.** The hang is inside `disconnect()`, proven by the markers, not inferred from reading code.
- **There is no red-to-green control here**, because I cannot reproduce the hang on demand. Two earlier fixes in this area (#285, #289) looked right and did not resolve the flake. I'm not claiming this one does.
- **What is controlled** is that the new branch is live rather than dead: setting the bound to `1ns` makes `reconnection_c2s` fail with `RemoteDisconnectEventMissing (290)` from `remote_ext.rs:1134`. The timeout path is reachable and returns what it should.
- All five reconnection tests pass with the bound in place — three consecutive runs of the previously-wedging one included. Clippy clean.

This is a bound, in the same shape as #285: it converts an indefinite hang into a diagnosable error. If the flake persists, the next CI log names a phase instead of a silence.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7