### PR TITLE
fix: bind a packet's header CID to the session that authenticated

### DIFF
--- a/citadel_proto/src/proto/packet_processor/deregister_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/deregister_packet.rs
@@ -74,6 +74,30 @@ pub async fn process_deregister<R: Ratchet, T: PlatformOps>(
         );
         let header = &header;
         let session_cid = header.session_cid.get();
+
+        // The CID in the header must be the one this session authenticated as.
+        //
+        // Nothing bound them. `get_orientation_safe_ratchet(.., None)` returns
+        // the SESSION's own C2S ratchet, so the AEAD proves that the holder of
+        // this session's key wrote the header — not that the CID inside it is
+        // theirs. A connected client that writes somebody else's CID into a
+        // DO_DEREGISTER header therefore authenticated it perfectly well, and
+        // `deregister_client_from_self` below called
+        // `delete_client_by_cid(that value)`: any account, deleted by any
+        // authenticated user.
+        //
+        // The STAGE_SUCCESS branch already reads `session.session_cid` for
+        // exactly this reason; this is the same question asked one branch
+        // earlier. Left as a check rather than a substitution because the header
+        // value is what the rest of this function replies with, and for an
+        // honest client the two are equal.
+        if let Some(authenticated_cid) = session.session_cid.get() {
+            if session_cid != authenticated_cid {
+                log::warn!(target: "citadel", "Dropping deregister: header names {session_cid}, but this session authenticated as {authenticated_cid}");
+                return Ok(PrimaryProcessorResult::Void);
+            }
+        }
+
         let security_level = header.security_level.into();
 
         match header.cmd_aux {

--- a/citadel_proto/src/proto/packet_processor/file_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/file_packet.rs
@@ -254,6 +254,26 @@ pub fn process_file_packet<R: Ratchet, T: PlatformOps>(
                                 ))
                             };
                             let virtual_target = header_to_response_vconn_type(&header);
+                            // Same binding as the deregister path: the C2S
+                            // ratchet that validated this packet is the
+                            // SESSION's, so the header's CID is attacker-chosen
+                            // for any connected client. This operates on that
+                            // user's RE-VFS, and the comment beside it already
+                            // says "the cid of the sender" — this is what makes
+                            // that true.
+                            // C2S only. A PEER's RE-VFS request is proxied
+                            // (target_cid != 0) and its header legitimately
+                            // names the peer, not this session — binding it
+                            // there broke test_p2p_file_transfer_revfs, which is
+                            // how the scope of this check was found.
+                            if let Some(authenticated_cid) = session.session_cid.get() {
+                                if header.target_cid.get() == 0
+                                    && header.session_cid.get() != authenticated_cid
+                                {
+                                    log::warn!(target: "citadel", "Dropping RE-VFS request: header names {}, session authenticated as {authenticated_cid}", header.session_cid.get());
+                                    return Ok(PrimaryProcessorResult::Void);
+                                }
+                            }
                             let revfs_cid = header.session_cid.get();
                             let resp_target_cid = get_resp_target_cid_from_header(&header);
                             let delete_on_pull = packet.delete_on_pull;
@@ -334,6 +354,26 @@ pub fn process_file_packet<R: Ratchet, T: PlatformOps>(
                         Some(payload) => {
                             let virtual_path = payload.virtual_path;
                             // we use the cid of the sender, because, they are requesting to alter data here
+                            // Same binding as the deregister path: the C2S
+                            // ratchet that validated this packet is the
+                            // SESSION's, so the header's CID is attacker-chosen
+                            // for any connected client. This operates on that
+                            // user's RE-VFS, and the comment beside it already
+                            // says "the cid of the sender" — this is what makes
+                            // that true.
+                            // C2S only. A PEER's RE-VFS request is proxied
+                            // (target_cid != 0) and its header legitimately
+                            // names the peer, not this session — binding it
+                            // there broke test_p2p_file_transfer_revfs, which is
+                            // how the scope of this check was found.
+                            if let Some(authenticated_cid) = session.session_cid.get() {
+                                if header.target_cid.get() == 0
+                                    && header.session_cid.get() != authenticated_cid
+                                {
+                                    log::warn!(target: "citadel", "Dropping RE-VFS request: header names {}, session authenticated as {authenticated_cid}", header.session_cid.get());
+                                    return Ok(PrimaryProcessorResult::Void);
+                                }
+                            }
                             let re_vfs_cid = header.session_cid.get();
                             let resp_target_cid = get_resp_target_cid_from_header(&header);
                             let pers = session.account_manager.get_persistence_handler().clone();


### PR DESCRIPTION
An authenticated client could **delete any other account**, and read or delete any other user's server-side files, by writing that user's CID into a header it signed.

Nothing bound the two. `get_orientation_safe_ratchet(.., None)` returns the **session's own** C2S ratchet, so `validation::aead::validate` proves that the holder of this session's key wrote the header — never that the CID inside it is theirs. `header.session_cid` is used 48 times across `citadel_proto` and compared against the session's authenticated CID in **none** of them.

Three sinks take it at face value on the C2S path:

| sink | consequence |
|---|---|
| `deregister_packet.rs:76` → `delete_client_by_cid(value)` | any account deleted |
| `file_packet.rs:257` → `revfs_get_file_info(cid, path)` | another user's file metadata |
| `file_packet.rs:337` → `revfs_delete(cid, path)` | another user's file deleted |

The deregister handler already reads `session.session_cid` one branch further down, for exactly this reason — the same question asked one branch too late. `file_packet`'s own comment says *"we use the cid of the sender"*; this is what makes that true.

**Scope was found by the tests, not by reasoning.** The first version broke `test_p2p_file_transfer_revfs`: a peer's RE-VFS request is proxied and its header legitimately names the peer. Only `target_cid == 0` is bound. Pre-authentication packets are unaffected — `session.session_cid` is `None` during register, preconnect and connect, which is precisely what makes a blanket check unsafe there.

Left as a check rather than a substitution, because the header value is what the rest of each handler replies with and for an honest client the two are equal.

97/97 `citadel_sdk` and 50/50 `citadel_proto` pass.

Found by a Fable audit fleet, confirmed independently against the code before acting.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7