### PR TITLE
perf: stop rewriting the whole account file for operations that changed nothing

### DIFF
--- a/citadel_user/src/backend/file_io_backend.rs
+++ b/citadel_user/src/backend/file_io_backend.rs
@@ -308,6 +308,12 @@ impl<R: Ratchet, Fcm: Ratchet> BackendConnection<R, Fcm> for FileIOBackend<R, Fc
             .memory_backend
             .remove_byte_map_value(session_cid, peer_cid, key, sub_key)
             .await?;
+        // Nothing removed, nothing to persist. Each of these saves is a full
+        // bincode of the account plus a whole-file overwrite, so a removal that
+        // found no key used to cost exactly as much as one that found it.
+        if res.is_none() {
+            return Ok(res);
+        }
         self.save_cnac_by_cid(session_cid).await.map(|_| res)
     }
 
@@ -319,10 +325,25 @@ impl<R: Ratchet, Fcm: Ratchet> BackendConnection<R, Fcm> for FileIOBackend<R, Fc
         sub_key: &str,
         value: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, AccountError> {
+        // Rewriting the account file to store the value it already holds is the
+        // same cost as storing a new one. The comparison is a HashMap lookup and
+        // a memcmp against data already in memory; the write it can avoid is a
+        // bincode of every key ever stored for this CID plus a full-file
+        // overwrite. ILM re-stores unchanged tracker state per message, so this
+        // is the ordinary case, not an edge one.
+        let unchanged = matches!(
+            self.memory_backend
+                .get_byte_map_value(session_cid, peer_cid, key, sub_key)
+                .await?,
+            Some(existing) if existing == value
+        );
         let res = self
             .memory_backend
             .store_byte_map_value(session_cid, peer_cid, key, sub_key, value)
             .await?;
+        if unchanged {
+            return Ok(res);
+        }
         self.save_cnac_by_cid(session_cid).await.map(|_| res)
     }
 
@@ -332,11 +353,15 @@ impl<R: Ratchet, Fcm: Ratchet> BackendConnection<R, Fcm> for FileIOBackend<R, Fc
         peer_cid: u64,
         key: &str,
     ) -> Result<HashMap<String, Vec<u8>>, AccountError> {
-        let res = self
-            .memory_backend
+        // A READ. This used to call `save_cnac_by_cid` too, which serialises the
+        // entire ClientNetworkAccount — `byte_map` and all — and overwrites the
+        // account file. Reading changed nothing, so the write persisted nothing;
+        // it just made every key listing cost a full-account rewrite. Its
+        // single-value sibling `get_byte_map_value` never did this, which is
+        // what identifies it as a slip rather than a decision.
+        self.memory_backend
             .get_byte_map_values_by_key(session_cid, peer_cid, key)
-            .await?;
-        self.save_cnac_by_cid(session_cid).await.map(|_| res)
+            .await
     }
 
     async fn remove_byte_map_values_by_key(
@@ -349,6 +374,9 @@ impl<R: Ratchet, Fcm: Ratchet> BackendConnection<R, Fcm> for FileIOBackend<R, Fc
             .memory_backend
             .remove_byte_map_values_by_key(session_cid, peer_cid, key)
             .await?;
+        if res.is_empty() {
+            return Ok(res);
+        }
         self.save_cnac_by_cid(session_cid).await.map(|_| res)
     }
 

--- a/citadel_user/src/backend/std_file_io.rs
+++ b/citadel_user/src/backend/std_file_io.rs
@@ -6,7 +6,39 @@ use crate::backend::file_io::{AsyncStreamWriter, DirEntry, FileIO};
 use crate::misc::AccountError;
 use async_trait::async_trait;
 use citadel_io::tokio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::AsyncWriteExt;
+
+/// Rename `from` over `to`, retrying briefly on Windows.
+///
+/// POSIX replaces the destination even while a reader holds it open. Windows
+/// does not: `MoveFileEx` fails with a sharing violation if another handle is
+/// open without `FILE_SHARE_DELETE`, and Rust's `File::open` does not request
+/// it. Reads of the account file are short, so a few retries cover the overlap;
+/// without them this change would turn a torn read into a failed write on
+/// Windows, which is not a trade worth making.
+#[cfg(windows)]
+async fn rename_replacing(from: &str, to: &str) -> std::io::Result<()> {
+    const ATTEMPTS: usize = 5;
+    let mut last = None;
+    for attempt in 0..ATTEMPTS {
+        match tokio::fs::rename(from, to).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                last = Some(err);
+                if attempt + 1 < ATTEMPTS {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
+        }
+    }
+    Err(last.expect("the loop runs at least once"))
+}
+
+#[cfg(not(windows))]
+async fn rename_replacing(from: &str, to: &str) -> std::io::Result<()> {
+    tokio::fs::rename(from, to).await
+}
 
 /// Standard filesystem I/O using `tokio::fs`.
 pub struct StdFileIO;
@@ -19,10 +51,55 @@ impl FileIO for StdFileIO {
             .map_err(|err| AccountError::io(err.to_string()))
     }
 
+    /// Write via a sibling temp file and a rename, so the destination is never
+    /// observed half-written.
+    ///
+    /// `tokio::fs::write` truncates and then writes. The account file it is
+    /// asked to write here is the whole `ClientNetworkAccount` — ratchet state
+    /// and every stored key — and it is rewritten on every byte-map mutation,
+    /// so the truncated window is not rare: a crash inside it leaves a file that
+    /// `bincode::deserialize` cannot read, and the loader logs the failure and
+    /// carries on without the account. A rename over an existing path is atomic
+    /// on POSIX and on Windows via `MoveFileEx`, so a reader sees either the old
+    /// bytes or the new ones.
+    ///
+    /// The temp name carries the process id and a counter because two writers
+    /// may target one path — `save_cnac_by_cid` can run concurrently for the
+    /// same CID. A shared temp name would let them interleave INTO the temp
+    /// file, which is worse than the torn write this replaces. Distinct names
+    /// keep the outcome last-writer-wins, which is what it already was.
+    ///
+    /// Deliberately no `fsync`: it would make the destination survive a machine
+    /// crash, at the cost of a device flush on a path that is already too hot —
+    /// the same write amplification this change exists to reduce. Atomicity of
+    /// the replacement is the property that was missing; durability was never
+    /// offered here, since the previous implementation did not sync either.
     async fn write_file(&self, path: &str, data: &[u8]) -> Result<(), AccountError> {
-        tokio::fs::write(path, data)
-            .await
-            .map_err(|err| AccountError::io(err.to_string()))
+        static NEXT: AtomicU64 = AtomicU64::new(0);
+        // A sibling, so the rename stays within one filesystem — across a mount
+        // boundary `rename` fails with EXDEV rather than being atomic. The
+        // suffix keeps the extension off the one the account loader filters on,
+        // so a temp file left behind by a crash is never mistaken for an
+        // account.
+        let temp = format!(
+            "{path}.{}-{}.cnactmp",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        );
+
+        if let Err(err) = tokio::fs::write(&temp, data).await {
+            // Best effort: the temp file may not exist, and the write error is
+            // what the caller needs to see either way.
+            let _ = tokio::fs::remove_file(&temp).await;
+            return Err(AccountError::io(err.to_string()));
+        }
+
+        if let Err(err) = rename_replacing(&temp, path).await {
+            let _ = tokio::fs::remove_file(&temp).await;
+            return Err(AccountError::io(err.to_string()));
+        }
+
+        Ok(())
     }
 
     async fn read_file(&self, path: &str) -> Result<Vec<u8>, AccountError> {
@@ -107,5 +184,143 @@ impl AsyncStreamWriter for StdStreamWriter {
             .sync_all()
             .await
             .map_err(|err| AccountError::io(err.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::file_io::FileIO;
+
+    /// One writer's payload, self-identifying so a mixture of two is detectable.
+    fn payload(marker: u8, len: usize) -> Vec<u8> {
+        vec![marker; len]
+    }
+
+    fn temp_dir() -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "citadel-std-file-io-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// A reader must never observe a half-written file.
+    ///
+    /// `tokio::fs::write` truncates and then writes, so a reader that lands in
+    /// that window sees a short file — and the account file it writes is bincode,
+    /// which a short read cannot deserialise. The payloads here are two different
+    /// lengths of two different bytes, so any observation that is neither one
+    /// nor the other is a torn read.
+    ///
+    /// Unix only. On Windows a reader holding the file open can make the rename
+    /// fail outright rather than tear (see `rename_replacing`), so the same race
+    /// measures a different property there and the retry window would make it
+    /// timing-dependent.
+    #[cfg(unix)]
+    #[citadel_io::tokio::test]
+    async fn a_concurrent_reader_never_sees_a_partial_write() {
+        let dir = temp_dir();
+        let path = dir.join("account.hca");
+        let path_str = path.to_string_lossy().to_string();
+        let io = StdFileIO;
+
+        let short = payload(b'a', 4_096);
+        let long = payload(b'b', 262_144);
+        io.write_file(&path_str, &long).await.unwrap();
+
+        let reader_path = path.clone();
+        let reader = citadel_io::tokio::task::spawn_blocking(move || {
+            let mut torn = Vec::new();
+            for _ in 0..2_000 {
+                if let Ok(seen) = std::fs::read(&reader_path) {
+                    let complete = seen.iter().all(|b| *b == b'a') && seen.len() == 4_096
+                        || seen.iter().all(|b| *b == b'b') && seen.len() == 262_144;
+                    if !complete {
+                        torn.push(seen.len());
+                    }
+                }
+            }
+            torn
+        });
+
+        for i in 0..200 {
+            let data = if i % 2 == 0 { &short } else { &long };
+            io.write_file(&path_str, data).await.unwrap();
+        }
+
+        let torn = reader.await.unwrap();
+        assert!(
+            torn.is_empty(),
+            "the reader saw {} partial file(s), lengths {:?}",
+            torn.len(),
+            &torn[..torn.len().min(8)]
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The temp file is an implementation detail and must not outlive the write
+    /// — a leftover would accumulate one file per write, and the account loader
+    /// scans this directory.
+    ///
+    /// Not a control for the defect: the previous implementation created no temp
+    /// file at all, so it satisfies this trivially. It guards the new
+    /// implementation's own hygiene, which is a different thing.
+    #[citadel_io::tokio::test]
+    async fn no_temp_file_survives_a_write() {
+        let dir = temp_dir();
+        let path = dir.join("account.hca");
+        let io = StdFileIO;
+
+        for _ in 0..5 {
+            io.write_file(&path.to_string_lossy(), b"contents")
+                .await
+                .unwrap();
+        }
+
+        let left: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|name| name != "account.hca")
+            .collect();
+        assert!(left.is_empty(), "temp files left behind: {left:?}");
+        assert_eq!(std::fs::read(&path).unwrap(), b"contents");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A failed write must leave the previous contents readable rather than an
+    /// empty or truncated file: the destination is only touched by the rename,
+    /// which never runs.
+    ///
+    /// Also not a control — this particular failure (an unwritable path) never
+    /// reached the destination under the old implementation either. The failure
+    /// mode it could not survive was a crash MID-write, which no test can stage
+    /// in-process; `a_concurrent_reader_never_sees_a_partial_write` is the one
+    /// that discriminates.
+    #[citadel_io::tokio::test]
+    async fn a_failed_write_leaves_the_previous_contents() {
+        let dir = temp_dir();
+        let path = dir.join("account.hca");
+        let path_str = path.to_string_lossy().to_string();
+        let io = StdFileIO;
+
+        io.write_file(&path_str, b"original").await.unwrap();
+
+        // A path whose parent does not exist: the temp write fails, so the
+        // rename never happens.
+        let unwritable = dir.join("missing-dir").join("account.hca");
+        assert!(io
+            .write_file(&unwritable.to_string_lossy(), b"replacement")
+            .await
+            .is_err());
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"original");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/citadel_user/tests/primary.rs
+++ b/citadel_user/tests/primary.rs
@@ -479,6 +479,141 @@ mod tests {
         .await
     }
 
+    /// Every write to the account file, counted by deleting it and asking
+    /// whether the operation puts it back.
+    ///
+    /// The filesystem backend persists a byte-map mutation by serialising the
+    /// ENTIRE `ClientNetworkAccount` — ratchet state plus every key ever stored
+    /// for that CID — and overwriting the file. That is inherent to the format.
+    /// What was not inherent: doing it for operations that changed nothing.
+    ///
+    ///   * `get_byte_map_values_by_key` is a READ and saved anyway, so listing
+    ///     keys cost a full-account rewrite. Its single-value sibling
+    ///     `get_byte_map_value` never did, which is what marks it as a slip.
+    ///   * a remove that removed nothing, and a store of the value already
+    ///     held, each cost exactly as much as one that changed something. ILM
+    ///     re-stores unchanged tracker state per message, so that is the
+    ///     ordinary case.
+    ///
+    /// Deleting the file between operations is the measurement: if the
+    /// operation saves, the file comes back.
+    #[cfg(feature = "filesystem")]
+    #[tokio::test]
+    async fn a_byte_map_read_does_not_rewrite_the_account_file() -> Result<(), AccountError> {
+        use citadel_user::prelude::CNAC_SERIALIZED_EXTENSION;
+
+        citadel_logging::setup_log();
+        let BackendType::Filesystem(home) = generate_random_filesystem_dir() else {
+            panic!("generate_random_filesystem_dir stopped returning a filesystem backend");
+        };
+        let container =
+            TestContainer::new(BackendType::InMemory, BackendType::Filesystem(home.clone())).await;
+        let pers = container.client_acc_mgr.get_persistence_handler().clone();
+        let (client, _server) = container.create_cnac(USERNAME, PASSWORD, FULL_NAME).await;
+        let cid = client.get_cid();
+
+        /// This CID's account file under `home`, wherever the layout puts it.
+        ///
+        /// Named by CID rather than "the only .hca file": the SDK also keeps a
+        /// `0.hca` — the shared local-only account documented as the node's KV
+        /// store — beside it.
+        fn account_file(home: &str, cid: u64) -> std::path::PathBuf {
+            fn walk(dir: &std::path::Path, cid: u64, out: &mut Vec<std::path::PathBuf>) {
+                let Ok(entries) = std::fs::read_dir(dir) else {
+                    return;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        walk(&path, cid, out);
+                    } else if path.extension().and_then(|e| e.to_str())
+                        == Some(CNAC_SERIALIZED_EXTENSION)
+                        && path.file_stem().and_then(|e| e.to_str()) == Some(&cid.to_string())
+                    {
+                        out.push(path);
+                    }
+                }
+            }
+            let mut found = Vec::new();
+            walk(std::path::Path::new(home), cid, &mut found);
+            assert_eq!(
+                found.len(),
+                1,
+                "expected exactly one account file for {cid}: {found:?}"
+            );
+            found.remove(0)
+        }
+
+        let path = account_file(&home, cid);
+        let value = Vec::from("a value");
+
+        // A store of a NEW value must write — without this the assertions below
+        // pass on a backend that never persists anything at all.
+        std::fs::remove_file(&path).unwrap();
+        pers.store_byte_map_value(cid, 1234, "k", "sub", value.clone())
+            .await?;
+        assert!(path.exists(), "storing a new value must persist it");
+
+        // Storing the value it already holds changes nothing.
+        std::fs::remove_file(&path).unwrap();
+        pers.store_byte_map_value(cid, 1234, "k", "sub", value.clone())
+            .await?;
+        assert!(
+            !path.exists(),
+            "re-storing an identical value rewrote the account file"
+        );
+
+        // A read is a read.
+        pers.get_byte_map_value(cid, 1234, "k", "sub").await?;
+        assert!(
+            !path.exists(),
+            "get_byte_map_value rewrote the account file"
+        );
+        let listed = pers.get_byte_map_values_by_key(cid, 1234, "k").await?;
+        assert_eq!(listed.get("sub"), Some(&value), "the read must still read");
+        assert!(
+            !path.exists(),
+            "get_byte_map_values_by_key rewrote the account file"
+        );
+
+        // A removal that finds nothing removes nothing.
+        pers.remove_byte_map_value(cid, 1234, "k", "absent").await?;
+        assert!(
+            !path.exists(),
+            "a removal that removed nothing rewrote the account file"
+        );
+        pers.remove_byte_map_values_by_key(cid, 4321, "absent")
+            .await?;
+        assert!(
+            !path.exists(),
+            "a by-key removal that removed nothing rewrote the file"
+        );
+
+        // The controls: mutations that DO change something must still persist.
+        pers.store_byte_map_value(cid, 1234, "k", "sub", Vec::from("different"))
+            .await?;
+        assert!(path.exists(), "storing a changed value must persist it");
+
+        std::fs::remove_file(&path).unwrap();
+        pers.remove_byte_map_value(cid, 1234, "k", "sub").await?;
+        assert!(
+            path.exists(),
+            "a removal that removed something must persist it"
+        );
+
+        pers.store_byte_map_value(cid, 1234, "k", "sub", value.clone())
+            .await?;
+        std::fs::remove_file(&path).unwrap();
+        pers.remove_byte_map_values_by_key(cid, 1234, "k").await?;
+        assert!(
+            path.exists(),
+            "a by-key removal that removed something must persist it"
+        );
+
+        container.purge().await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_byte_map() -> Result<(), AccountError> {
         test_harness(|container, pers_cl, pers_se| async move {


### PR DESCRIPTION
The filesystem backend persists a byte-map mutation by serialising the **entire** `ClientNetworkAccount` — ratchet state plus every key ever stored for that CID — and overwriting the file. That is inherent to the format. Doing it for operations that changed nothing was not.

| operation | before | after |
|---|---|---|
| `get_byte_map_values_by_key` | **a read that wrote** — listing keys cost a full-account rewrite | no write |
| `store_byte_map_value` (same value) | full rewrite | no write |
| `remove_byte_map_value` (no such key) | full rewrite | no write |
| `remove_byte_map_values_by_key` (empty) | full rewrite | no write |

The read case is a slip rather than a decision: its single-value sibling `get_byte_map_value` never saved. The unchanged-store case is the *ordinary* one, not an edge — ILM re-stores unchanged tracker state per message. The comparison that avoids it is a `HashMap` lookup and a memcmp against data already in memory.

**Measurement.** The test deletes the account file and asks whether the operation puts it back — an exact count, not a proxy. It carries controls in both directions: storing a *new* value, and each removal that removes something, must still persist, or every assertion would pass on a backend that never writes at all.

### Atomic replacement

`write_file` now goes via a sibling temp file and a rename. `tokio::fs::write` truncates and then writes, and the file is the whole account — so a crash inside that window leaves bincode the loader cannot deserialise, and it logs the failure and carries on *without the account*. A concurrent-reader test observes this directly: against the old implementation it catches zero-length reads; against the rename it never does.

The temp name carries pid and a counter because `save_cnac_by_cid` can run concurrently for one CID, and a shared temp name would let two writers interleave *into* it — worse than the tear it replaces.

Windows needs the retry in `rename_replacing`: `MoveFileEx` fails with a sharing violation while another handle is open without `FILE_SHARE_DELETE`, and Rust's `File::open` does not request it. Without it, this change would trade a torn read for a failed write there.

No `fsync`, deliberately: durability was never offered here (the previous implementation did not sync either), and a device flush on this path is the same cost this change exists to reduce. Atomic *replacement* is the property that was missing.

Two of the three new `std_file_io` tests are labelled in-file as **not** controls — the previous implementation satisfies them trivially. Only the concurrent-reader test discriminates.

29 + 16 `citadel_user` tests and 97/97 `citadel_sdk` (`localhost-testing`, as CI runs it) pass.

Found by a Fable audit fleet.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7