### PR TITLE
fix: skip a byte-map write only when the file is known to match memory

### DIFF
--- a/citadel_user/src/backend/file_io_backend.rs
+++ b/citadel_user/src/backend/file_io_backend.rs
@@ -32,6 +32,20 @@ pub struct FileIOBackend<R: Ratchet, Fcm: Ratchet> {
     directory_store: Option<DirectoryStore>,
     home_dir: String,
     file_io: Arc<dyn FileIO>,
+    /// CIDs whose on-disk copy is known to be behind memory.
+    ///
+    /// The byte-map skips below decide "nothing changed" by comparing against
+    /// the IN-MEMORY map — and memory is written before the file is, and is
+    /// never rolled back when the write fails. So `memory == value` is not
+    /// evidence that `disk == value`, and a caller retrying a failed `set` with
+    /// the same bytes hit the skip and got `Ok` without the file ever being
+    /// written. That turns a retry loop — whose entire purpose is to survive a
+    /// transient I/O failure — into a silent no-op, and the change is gone after
+    /// a restart while every caller was told it succeeded.
+    ///
+    /// A CID is marked when its save fails and cleared when one succeeds, so the
+    /// skips are disabled for exactly as long as the file may be stale.
+    stale_on_disk: Arc<parking_lot::RwLock<std::collections::HashSet<u64>>>,
 }
 
 impl<R: Ratchet, Fcm: Ratchet> FileIOBackend<R, Fcm> {
@@ -42,6 +56,7 @@ impl<R: Ratchet, Fcm: Ratchet> FileIOBackend<R, Fcm> {
             memory_backend: MemoryBackend::default(),
             directory_store: None,
             file_io,
+            stale_on_disk: Arc::new(parking_lot::RwLock::new(std::collections::HashSet::new())),
         }
     }
 }
@@ -311,7 +326,7 @@ impl<R: Ratchet, Fcm: Ratchet> BackendConnection<R, Fcm> for FileIOBackend<R, Fc
         // Nothing removed, nothing to persist. Each of these saves is a full
         // bincode of the account plus a whole-file overwrite, so a removal that
         // found no key used to cost exactly as much as one that found it.
-        if res.is_none() {
+        if res.is_none() && self.disk_is_current(session_cid) {
             return Ok(res);
         }
         self.save_cnac_by_cid(session_cid).await.map(|_| res)
@@ -341,7 +356,7 @@ impl<R: Ratchet, Fcm: Ratchet> BackendConnection<R, Fcm> for FileIOBackend<R, Fc
             .memory_backend
             .store_byte_map_value(session_cid, peer_cid, key, sub_key, value)
             .await?;
-        if unchanged {
+        if unchanged && self.disk_is_current(session_cid) {
             return Ok(res);
         }
         self.save_cnac_by_cid(session_cid).await.map(|_| res)
@@ -374,7 +389,7 @@ impl<R: Ratchet, Fcm: Ratchet> BackendConnection<R, Fcm> for FileIOBackend<R, Fc
             .memory_backend
             .remove_byte_map_values_by_key(session_cid, peer_cid, key)
             .await?;
-        if res.is_empty() {
+        if res.is_empty() && self.disk_is_current(session_cid) {
             return Ok(res);
         }
         self.save_cnac_by_cid(session_cid).await.map(|_| res)
@@ -498,7 +513,25 @@ impl<R: Ratchet, Fcm: Ratchet> FileIOBackend<R, Fcm> {
             .get(&cid)
             .cloned()
             .ok_or(AccountError::account_client_non_exists(cid))?;
-        self.save_cnac(&cnac).await
+        let outcome = self.save_cnac(&cnac).await;
+        // Record whether the file now matches memory — see `stale_on_disk`.
+        match &outcome {
+            Ok(()) => {
+                let _ = self.stale_on_disk.write().remove(&cid);
+            }
+            Err(_) => {
+                let _ = self.stale_on_disk.write().insert(cid);
+            }
+        }
+        outcome
+    }
+
+    /// May a "nothing changed in memory" skip be trusted for this CID?
+    ///
+    /// Only when the file is known to match memory. After a failed save it does
+    /// not, and the next identical write is the retry that has to reach the disk.
+    fn disk_is_current(&self, cid: u64) -> bool {
+        !self.stale_on_disk.read().contains(&cid)
     }
 
     fn generate_cnac_local_save_path(&self, cid: u64, is_personal: bool) -> PathBuf {

--- a/citadel_user/tests/primary.rs
+++ b/citadel_user/tests/primary.rs
@@ -614,6 +614,114 @@ mod tests {
         Ok(())
     }
 
+    /// A retry after a failed disk write must reach the disk.
+    ///
+    /// The "nothing changed" skip decides by comparing against the IN-MEMORY
+    /// map — and memory is written before the file is, and is never rolled back
+    /// when the write fails. So `memory == value` is not evidence that
+    /// `disk == value`: a caller retrying a failed `set` with the same bytes hit
+    /// the skip and got `Ok` without the file ever being written, which turns a
+    /// retry loop — whose whole purpose is surviving a transient I/O failure —
+    /// into a silent no-op. The change is gone after a restart, and every caller
+    /// was told it succeeded.
+    ///
+    /// The failure is staged by making the directory unwritable, which is the
+    /// closest thing to a real transient I/O error a test can produce.
+    #[cfg(all(unix, feature = "filesystem"))]
+    #[tokio::test]
+    async fn a_retry_after_a_failed_write_still_reaches_the_disk() -> Result<(), AccountError> {
+        use citadel_user::prelude::CNAC_SERIALIZED_EXTENSION;
+        use std::os::unix::fs::PermissionsExt;
+
+        citadel_logging::setup_log();
+        let BackendType::Filesystem(home) = generate_random_filesystem_dir() else {
+            panic!("generate_random_filesystem_dir stopped returning a filesystem backend");
+        };
+        let container =
+            TestContainer::new(BackendType::InMemory, BackendType::Filesystem(home.clone())).await;
+        let pers = container.client_acc_mgr.get_persistence_handler().clone();
+        let (client, _server) = container.create_cnac(USERNAME, PASSWORD, FULL_NAME).await;
+        let cid = client.get_cid();
+
+        fn account_file(home: &str, cid: u64) -> std::path::PathBuf {
+            fn walk(dir: &std::path::Path, cid: u64, out: &mut Vec<std::path::PathBuf>) {
+                let Ok(entries) = std::fs::read_dir(dir) else {
+                    return;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        walk(&path, cid, out);
+                    } else if path.extension().and_then(|e| e.to_str())
+                        == Some(CNAC_SERIALIZED_EXTENSION)
+                        && path.file_stem().and_then(|e| e.to_str()) == Some(&cid.to_string())
+                    {
+                        out.push(path);
+                    }
+                }
+            }
+            let mut found = Vec::new();
+            walk(std::path::Path::new(home), cid, &mut found);
+            assert_eq!(
+                found.len(),
+                1,
+                "expected one account file for {cid}: {found:?}"
+            );
+            found.remove(0)
+        }
+
+        pers.store_byte_map_value(cid, 1234, "k", "sub", Vec::from("first"))
+            .await?;
+        let path = account_file(&home, cid);
+        let dir = path.parent().unwrap().to_path_buf();
+        let before = std::fs::read(&path).unwrap();
+
+        // Stage the I/O failure.
+        let original = std::fs::metadata(&dir).unwrap().permissions();
+        let mut readonly = original.clone();
+        readonly.set_mode(0o555);
+        std::fs::set_permissions(&dir, readonly).unwrap();
+
+        let failed = pers
+            .store_byte_map_value(cid, 1234, "k", "sub", Vec::from("second"))
+            .await;
+        std::fs::set_permissions(&dir, original).unwrap();
+        assert!(
+            failed.is_err(),
+            "the write did not fail, so this test is staging nothing",
+        );
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "the failed write reached the file, so there is nothing to retry",
+        );
+
+        // The retry: identical bytes, and memory already holds them.
+        pers.store_byte_map_value(cid, 1234, "k", "sub", Vec::from("second"))
+            .await?;
+        assert_ne!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "the retry was skipped as unchanged, so the value was acknowledged but never stored",
+        );
+
+        // And the skip works again once the file is current — or this fix would
+        // simply be the optimisation removed.
+        let after_retry = std::fs::read(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        pers.store_byte_map_value(cid, 1234, "k", "sub", Vec::from("second"))
+            .await?;
+        assert!(
+            !path.exists(),
+            "an identical store rewrote the file even though the disk was current",
+        );
+        // Put it back: purge expects the account it is being asked to remove.
+        std::fs::write(&path, &after_retry).unwrap();
+
+        container.purge().await;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn test_byte_map() -> Result<(), AccountError> {
         test_harness(|container, pers_cl, pers_se| async move {


### PR DESCRIPTION
**Regression from #294**, found by an audit fleet run over that campaign's own diff.

#294 stopped rewriting the whole account file when a byte-map store stored an identical value, or a removal removed nothing. It decided "nothing changed" by comparing against the **in-memory** map — and memory is written *before* the file is, and is never rolled back when the write fails. So `memory == value` is not evidence that `disk == value`.

The consequence is worse than a stale file:

| | before #294 | after #294 | now |
|---|---|---|---|
| write fails | memory ahead of disk | memory ahead of disk | memory ahead of disk, **CID marked stale** |
| retry, same bytes | rewrites the file, succeeds | **skipped — `Ok`, file never written** | rewrites the file, succeeds |
| identical store, disk current | rewrites the file | skipped | skipped |

`backend_save` retries with 100/200/400 ms backoff and identical bytes, so a retry loop whose entire purpose is surviving a transient I/O failure became a silent no-op: the change absent after a restart, every caller told it succeeded.

A CID is marked stale when its save fails and cleared when one succeeds; all three skips ask `disk_is_current` first. The skips are disabled for exactly as long as the file may be behind memory, and no longer.

**Test** stages the failure by making the account directory unwritable — the closest a test can get to a transient I/O error — and asserts on the file's bytes: unchanged after the failed write, changed after the retry. It also asserts the skip still works once the disk is current, or the fix would just be the optimisation removed. The control restores the merged condition and fails with *"acknowledged but never stored"*.

29 + 17 `citadel_user` and 97/97 `citadel_sdk` (`localhost-testing`) pass.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7