### PR TITLE
fix: a client whose hole punch failed must say so, not hand back a dead receiver

### DIFF
--- a/citadel_proto/src/proto/packet_processor/preconnect_packet.rs
+++ b/citadel_proto/src/proto/packet_processor/preconnect_packet.rs
@@ -715,6 +715,26 @@ fn handle_success_as_receiver<R: Ratchet, T: PlatformOps>(
                 Some(tcp_loaded_alerter_rx),
             );
         }
+    } else if state_container.udp_mode == UdpMode::Enabled {
+        // The punch failed, and this side has to say so — the same way the
+        // server's own fallback does at the STAGE0 handler.
+        //
+        // This branch only WARNED. On the initiator that leaves the pair from
+        // `session.rs` intact, so `connect_packet.rs` takes a receiver that is
+        // `Some` and hands it to the caller, and nothing will ever send on it.
+        // The SDK's documented use is to await that receiver, so a client behind
+        // an uncooperative NAT awaited forever while the connection itself was
+        // fine over TCP. The comment above records that exact outcome — "a 1.4s
+        // failure became a 90s hang" — as the reason an earlier install attempt
+        // was reverted; it was already shipping here, from the other direction.
+        //
+        // `empty()` rather than dropping only the sender, so the answer is the
+        // one every other site already uses: no receiver means no UDP. A
+        // receiver that resolves to an error would be a second encoding of the
+        // same fact, and this mechanism has enough of those.
+        log::warn!(target: "citadel", "No UDP splittable was specified; falling back to TCP only and reporting UDP as unavailable");
+        state_container.udp_mode = UdpMode::Disabled;
+        state_container.pre_connect_state.udp_channel_oneshot_tx = UdpChannelSender::empty();
     } else {
         log::warn!(target: "citadel", "No UDP splittable was specified. UdpMode: {:?}", state_container.udp_mode);
     }


### PR DESCRIPTION
The server's fallback sets `udp_mode = Disabled` when its punch fails (`preconnect_packet.rs:406`). The initiator's did not — it only warned.

So the one-shot pair installed at `session.rs:781` stays intact, connect SUCCESS takes a receiver that is `Some`, and **nothing will ever send on it**. Awaiting that receiver is the SDK's documented use, so a client behind an uncooperative NAT awaits forever while the connection itself is fine over TCP.

The comment directly above this branch records that exact outcome — *"a 1.4s failure became a 90s hang"* — as the reason an earlier install attempt was reverted. It was already shipping here, from the other direction, and no test covers it because localhost always punches successfully.

| side | punch fails | before | after |
|---|---|---|---|
| server | ✔ handled | `udp_mode = Disabled`, no receiver | unchanged |
| client | ✗ | warn only; receiver present, never resolves | `udp_mode = Disabled`, no receiver |

Reported as `empty()` rather than by dropping only the sender: *no receiver means no UDP* is the encoding every other site already uses, and a receiver that resolves to an error would be a second encoding of the same fact. This mechanism has enough of those.

**Callers see a behaviour change on punch failure, and it is the point:** an `Option` that is `None`, instead of an await that never returns.

97/97 `citadel_sdk` (`localhost-testing`).

Found by an architectural review of the UDP one-shot, run alongside two other agents on an unrelated CI flake — this was not the thing any of them were asked to look for.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7