### PR TITLE
fix: an abrupt session end must resolve the caller's disconnect, not the kernel's

### DIFF
--- a/citadel_proto/src/proto/session.rs
+++ b/citadel_proto/src/proto/session.rs
@@ -697,7 +697,33 @@ impl<R: Ratchet, T: PlatformOps> CitadelSession<R, T> {
 
                 log::warn!(target: "citadel", "[DC_SIGNAL:execute] C2S session ending | cid: {:?} | ticket: {} | reason: {} | strong_count: {} | is_provisional: {}",
                     cid, ticket.0, reason.as_str(), this_close.strong_count(), this_close.is_provisional());
-                this_close.send_session_dc_signal(Some(ticket), false, "Inbound stream ending");
+                // `None`, not `Some(ticket)` — `ticket` here is the KERNEL
+                // ticket, and passing it takes the `(Some(explicit), _)` branch
+                // in `send_session_dc_signal`, which is precisely the branch
+                // that skips `pending_c2s_disconnect_ticket`.
+                //
+                // That field exists for this exact situation, and its own
+                // comment says so: "an application-initiated disconnect must
+                // resolve with ITS ticket even when the session ends abruptly
+                // (lost FINAL)". This arm defeated it. So when the stream ended
+                // between `disconnect()` sending STAGE0 and the FINAL being
+                // processed, the signal went to `{kernel_ticket, cid}` — a key
+                // nobody holds — and `try_c2s_disconnect` then suppressed the
+                // FINAL handler's correctly-ticketed signal as a duplicate. The
+                // caller's subscription received NOTHING and timed out after 30s
+                // with `RemoteDisconnectEventMissing`.
+                //
+                // Found by the `[dc-wait]` probe: "the subscription carried 0
+                // other event(s)". Zero is what rules out a misrouted Disconnect
+                // among live traffic and points at nothing being routed here at
+                // all.
+                //
+                // With `None`, the match resolves `(None, Some(pending))` to the
+                // caller's own ticket and reports success — the session is gone,
+                // which is what `disconnect()` asked for. With no pending
+                // disconnect it falls to `(None, None)` and behaves exactly as
+                // before.
+                this_close.send_session_dc_signal(None, false, "Inbound stream ending");
 
                 Err((err, cid))
             }

--- a/citadel_proto/tests/an_abrupt_end_resolves_the_callers_disconnect.rs
+++ b/citadel_proto/tests/an_abrupt_end_resolves_the_callers_disconnect.rs
@@ -1,0 +1,81 @@
+//! A session that ends abruptly must resolve the caller's `disconnect()`, not
+//! the kernel's ticket.
+//!
+//! `send_session_dc_signal` fires ONCE per session — `try_c2s_disconnect` sees
+//! to that — and it routes by `(ticket, cid)`. So whichever path signals first
+//! decides which subscription hears about it, and every later path is silently
+//! suppressed as a duplicate.
+//!
+//! `execute`'s error arm passed `Some(kernel_ticket)`, which takes the
+//! `(Some(explicit), _)` branch and skips `pending_c2s_disconnect_ticket` — the
+//! field that exists for exactly this case, whose own comment says an
+//! application-initiated disconnect must resolve with ITS ticket even when the
+//! session ends abruptly. So when the stream ended between `disconnect()`
+//! sending STAGE0 and the FINAL being processed, the signal went to a key nobody
+//! held, the FINAL handler's correct signal was suppressed, and the caller's
+//! subscription received nothing for thirty seconds.
+//!
+//! WHAT THIS TEST DOES NOT DO.
+//!
+//! The behavioural test needs a lost FINAL staged on a live session, which the
+//! harness cannot currently express. This is a source scan: it catches the arm
+//! being changed BACK, which is the realistic regression, and it cannot catch a
+//! `None` that reaches a different match. Said here rather than implied, because
+//! the fix it guards was itself found only after an earlier refutation of mine
+//! checked the happy path and stopped.
+
+use std::fs;
+use std::path::Path;
+
+fn session_source() -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/proto/session.rs");
+    let text = fs::read_to_string(&path).expect("session.rs must be readable");
+    text.lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn the_stream_ending_does_not_claim_the_disconnect_ticket() {
+    let code = session_source();
+    assert!(
+        code.contains(r#"send_session_dc_signal(None, false, "Inbound stream ending")"#),
+        "the inbound-stream-ending signal no longer passes None.\n\
+         Passing Some(kernel_ticket) takes the (Some(explicit), _) branch, which skips \
+         pending_c2s_disconnect_ticket — so an application's disconnect() is answered on a \
+         ticket nobody holds, and try_c2s_disconnect then suppresses the FINAL handler's \
+         correct signal as a duplicate. The caller waits out its 30s budget and reports \
+         RemoteDisconnectEventMissing.",
+    );
+}
+
+#[test]
+fn the_pending_ticket_fallback_still_exists_for_it_to_reach() {
+    // The arm above is only correct while the fallback is there to catch it.
+    // Removing the (None, Some(pending)) branch would leave `None` resolving to
+    // the kernel ticket — the same defect, reached from the other side.
+    let code = session_source();
+    assert!(
+        code.contains("pending_c2s_disconnect_ticket.take()"),
+        "the pending-disconnect ticket is no longer consumed when the signal is sent",
+    );
+    assert!(
+        code.contains("(None, Some(pending)) => (pending, true)"),
+        "the fallback that resolves an application disconnect on ITS ticket is gone, \
+         so passing None now resolves to the kernel ticket instead",
+    );
+}
+
+#[test]
+fn the_signal_is_still_once_per_session() {
+    // The whole hazard rests on this. If the gate were ever removed the ordering
+    // would stop mattering and these assertions would be guarding nothing — a
+    // change that makes this file pointless should say so out loud.
+    let code = session_source();
+    assert!(
+        code.contains("disconnect_tracker.try_c2s_disconnect(session_ticket)"),
+        "the once-per-session gate is gone; if that is deliberate, this file's \
+         premise no longer holds and it should be revisited rather than left passing",
+    );
+}


### PR DESCRIPTION
Found by the `[dc-wait]` probe merged in #297, on the **fourth** occurrence of an intermittent failure whose three earlier occurrences produced no evidence at all:

```
[dc-wait] timed out waiting for a Disconnect for cid 3663251634092307157;
          the subscription carried 0 other event(s)
```

**Zero is the whole finding.** It rules out a `Disconnect` misrouted among live traffic, and says nothing was routed to that subscription for thirty seconds.

### The mechanism

`execute`'s error arm passed `Some(kernel_ticket)`, which takes the `(Some(explicit), _)` branch in `send_session_dc_signal` — the one branch that skips `pending_c2s_disconnect_ticket`. That field exists for exactly this case, and its own comment says so:

> *An application-initiated disconnect must resolve with ITS ticket even when the session ends abruptly (lost FINAL).*

So when the inbound stream ended between `disconnect()` sending STAGE0 and the FINAL being processed:

1. the signal went to `{kernel_ticket, cid}` — a key nobody holds;
2. `try_c2s_disconnect`, which fires **once per session**, then suppressed the FINAL handler's correctly-ticketed signal as a duplicate;
3. the caller's subscription received nothing and timed out after 30 s with `RemoteDisconnectEventMissing`.

Passing `None` resolves `(None, Some(pending))` to the caller's own ticket and reports success — the session is gone, which is what `disconnect()` asked for. With no pending disconnect it falls to `(None, None)` and behaves exactly as before. `Drop` already passed `None`; this arm was the outlier.

### An earlier refutation of mine was wrong, instructively

I dismissed a double-take hypothesis two waves ago by verifying that the graceful FINAL path clears the pending marker **and** emits with the explicit ticket. Both true, and irrelevant — I never checked whether that emission could be **suppressed** by an earlier signal. A refutation that walks the happy path and stops is not a refutation.

108/108 `citadel_sdk` (`localhost-testing`) and 50/50 `citadel_proto`.

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7