### PR TITLE
diag: name the stage a peer file transfer hangs in

### DIFF
--- a/citadel_sdk/src/prefabs/client/peer_connection.rs
+++ b/citadel_sdk/src/prefabs/client/peer_connection.rs
@@ -919,19 +919,57 @@ mod tests {
                                 .expect("Failed to send file");
                         } else {
                             // TODO: route file-transfer + other events to peer channel
-                            let mut handle = conn
-                                .incoming_object_transfer_handles
-                                .take()
-                                .unwrap()
-                                .recv()
-                                .await
-                                .unwrap();
+                            // Bounded, so a failure names the stage it stopped at.
+                            //
+                            // `case_2` times out at the rstest budget of 180s on
+                            // macOS, intermittently, and the report is the bare
+                            // "Timeout 180s expired" — which cannot say whether
+                            // the handle never arrived, or arrived and the
+                            // transfer then stalled part way. Those are different
+                            // bugs. Two other intermittent failures in this suite
+                            // were solved this session by exactly this move, and
+                            // neither yielded to reading the code.
+                            //
+                            // The budgets are generous fractions of the 180s the
+                            // test already allows, so this cannot turn a slow
+                            // machine into a failure it would not otherwise have
+                            // had — it only replaces silence with a sentence.
+                            const HANDLE_BUDGET: std::time::Duration =
+                                std::time::Duration::from_secs(60);
+                            const STATUS_BUDGET: std::time::Duration =
+                                std::time::Duration::from_secs(60);
+
+                            let mut handles = conn.incoming_object_transfer_handles.take().unwrap();
+                            let mut handle = match citadel_io::tokio::time::timeout(
+                                HANDLE_BUDGET,
+                                handles.recv(),
+                            )
+                            .await
+                            {
+                                Ok(Some(handle)) => handle,
+                                Ok(None) => panic!(
+                                    "the incoming-transfer channel closed before any handle arrived"
+                                ),
+                                Err(_) => panic!(
+                                    "no incoming file-transfer handle within {HANDLE_BUDGET:?}: the sender never started, or its request never routed here"
+                                ),
+                            };
                             handle.accept().unwrap();
 
                             use citadel_types::proto::ObjectTransferStatus;
                             use futures::StreamExt;
                             let mut path = None;
-                            while let Some(status) = handle.next().await {
+                            while let Some(status) = match citadel_io::tokio::time::timeout(
+                                STATUS_BUDGET,
+                                handle.next(),
+                            )
+                            .await
+                            {
+                                Ok(status) => status,
+                                Err(_) => panic!(
+                                    "the transfer stalled: no status within {STATUS_BUDGET:?}, last seen {path:?}"
+                                ),
+                            } {
                                 match status {
                                     ObjectTransferStatus::ReceptionComplete => {
                                         let cmp =


### PR DESCRIPTION
`test_peer_to_peer_file_transfer::case_2` times out intermittently at the rstest budget on macOS, and the report is the bare `Timeout 180s expired`. That cannot say whether the incoming handle **never arrived**, or arrived and the transfer then **stalled part way** — different bugs, different fixes.

Both awaits in the receive path were unbounded: the handle `recv()` and the status stream. Each is now bounded at 60 s — a generous fraction of the 180 s the test already allows, so a slow machine cannot fail here that would not have failed anyway. What changes is that silence becomes a sentence:

```
no incoming file-transfer handle within 60s: the sender never started, or its
request never routed here

the transfer stalled: no status within 60s, last seen <path>
```

### Third time tonight, and the first two both yielded

| flake | what solved it |
|---|---|
| UDP one-shot race | a CI log's **ordering** — the take falling between two hole-punch completions → #298 |
| missing `Disconnect` | a probe reporting **"0 other events"** → #302 |
| this one | not yet — hence the probe |

Neither of the first two yielded to reading the code, and 22 local runs across four configurations reproduced neither.

An earlier round already bounded this same test's UDP receives (#292), for the same reason: every connected **pair** runs those assertions, so three peers is three pairs. This is the file-transfer half of the same test.

**Control:** reducing the handle budget to 1 ms fails both cases with the *handle* message, not the status one.

108/108 `citadel_sdk` (`localhost-testing`).

https://claude.ai/code/session_01CQKcBi2QVjvJBEA8StPfN7